### PR TITLE
Fix Docker workflow permissions for ghcr.io push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Fixes the `permission_denied: write_package` error in the Docker workflow.

## Problem

The Docker build workflow failed with:
```
ERROR: failed to build: denied: permission_denied: write_package
```

## Solution

Add additional permissions to the workflow:
- `attestations: write` - Required for container signing
- `id-token: write` - Required for OIDC token generation

## Note

If this doesn't resolve the issue, the repository settings may need to be updated:
- Settings → Actions → General → Workflow permissions → "Read and write permissions"
