### PR TITLE
feat: add SSE streaming endpoint for deduplication

### DIFF
--- a/pkg/sse/sse.go
+++ b/pkg/sse/sse.go
@@ -1,0 +1,141 @@
+// Package sse provides Server-Sent Events support for streaming
+// pipeline progress to clients.
+package sse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Stage identifies a pipeline processing stage.
+type Stage string
+
+const (
+	StageEmbedding  Stage = "embedding"
+	StageClustering Stage = "clustering"
+	StageSelection  Stage = "selection"
+	StageCompress   Stage = "compress"
+	StageMMR        Stage = "mmr"
+)
+
+// ProgressEvent is sent during processing to report stage progress.
+type ProgressEvent struct {
+	Stage    Stage            `json:"stage"`
+	Progress float64          `json:"progress"`
+	Stats    *json.RawMessage `json:"stats,omitempty"`
+}
+
+// CompleteEvent is sent when processing finishes.
+type CompleteEvent struct {
+	Chunks json.RawMessage `json:"chunks"`
+	Stats  json.RawMessage `json:"stats"`
+}
+
+// ErrorEvent is sent when processing fails.
+type ErrorEvent struct {
+	Error string `json:"error"`
+	Stage Stage  `json:"stage,omitempty"`
+}
+
+// Writer wraps an http.ResponseWriter for SSE output.
+// It sets the required headers and provides methods to send typed events.
+type Writer struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+}
+
+// NewWriter prepares the response for SSE streaming.
+// Returns nil if the ResponseWriter does not support flushing.
+func NewWriter(w http.ResponseWriter) *Writer {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	return &Writer{w: w, flusher: flusher}
+}
+
+// SendProgress emits a progress event for the given stage.
+func (s *Writer) SendProgress(stage Stage, progress float64) error {
+	evt := ProgressEvent{Stage: stage, Progress: progress}
+	return s.sendEvent("progress", evt)
+}
+
+// SendProgressWithStats emits a progress event that includes stage-level stats.
+func (s *Writer) SendProgressWithStats(stage Stage, progress float64, stats interface{}) error {
+	raw, err := json.Marshal(stats)
+	if err != nil {
+		return fmt.Errorf("marshal stats: %w", err)
+	}
+	rawMsg := json.RawMessage(raw)
+	evt := ProgressEvent{Stage: stage, Progress: progress, Stats: &rawMsg}
+	return s.sendEvent("progress", evt)
+}
+
+// SendComplete emits the final complete event with chunks and stats.
+func (s *Writer) SendComplete(chunks interface{}, stats interface{}) error {
+	chunksJSON, err := json.Marshal(chunks)
+	if err != nil {
+		return fmt.Errorf("marshal chunks: %w", err)
+	}
+	statsJSON, err := json.Marshal(stats)
+	if err != nil {
+		return fmt.Errorf("marshal stats: %w", err)
+	}
+	evt := CompleteEvent{
+		Chunks: json.RawMessage(chunksJSON),
+		Stats:  json.RawMessage(statsJSON),
+	}
+	return s.sendEvent("complete", evt)
+}
+
+// SendError emits an error event.
+func (s *Writer) SendError(stage Stage, errMsg string) error {
+	evt := ErrorEvent{Error: errMsg, Stage: stage}
+	return s.sendEvent("error", evt)
+}
+
+// sendEvent writes a single SSE event and flushes.
+func (s *Writer) sendEvent(eventType string, data interface{}) error {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal event data: %w", err)
+	}
+
+	_, err = fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", eventType, payload)
+	if err != nil {
+		return fmt.Errorf("write event: %w", err)
+	}
+	s.flusher.Flush()
+	return nil
+}
+
+// StageTimer tracks elapsed time for a pipeline stage.
+type StageTimer struct {
+	Stage   Stage
+	started time.Time
+}
+
+// NewStageTimer starts timing a stage.
+func NewStageTimer(stage Stage) *StageTimer {
+	return &StageTimer{Stage: stage, started: time.Now()}
+}
+
+// Elapsed returns the duration since the timer started.
+func (t *StageTimer) Elapsed() time.Duration {
+	return time.Since(t.started)
+}
+
+// ElapsedMs returns elapsed milliseconds.
+func (t *StageTimer) ElapsedMs() int64 {
+	return t.Elapsed().Milliseconds()
+}

--- a/pkg/sse/sse_test.go
+++ b/pkg/sse/sse_test.go
@@ -1,0 +1,209 @@
+package sse
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewWriter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := NewWriter(rec)
+	if sw == nil {
+		t.Fatal("expected non-nil Writer from httptest.ResponseRecorder")
+	}
+
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", cc)
+	}
+	if conn := rec.Header().Get("Connection"); conn != "keep-alive" {
+		t.Errorf("Connection = %q, want keep-alive", conn)
+	}
+}
+
+// nonFlushWriter does not implement http.Flusher.
+type nonFlushWriter struct {
+	http.ResponseWriter
+}
+
+func TestNewWriter_NoFlusher(t *testing.T) {
+	sw := NewWriter(&nonFlushWriter{})
+	if sw != nil {
+		t.Error("expected nil Writer when ResponseWriter does not support Flusher")
+	}
+}
+
+func TestSendProgress(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := NewWriter(rec)
+
+	if err := sw.SendProgress(StageClustering, 0.5); err != nil {
+		t.Fatalf("SendProgress: %v", err)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: progress") {
+		t.Error("missing 'event: progress' line")
+	}
+
+	// Extract data line
+	data := extractData(t, body, "progress")
+	var evt ProgressEvent
+	if err := json.Unmarshal([]byte(data), &evt); err != nil {
+		t.Fatalf("unmarshal progress event: %v", err)
+	}
+	if evt.Stage != StageClustering {
+		t.Errorf("stage = %q, want %q", evt.Stage, StageClustering)
+	}
+	if evt.Progress != 0.5 {
+		t.Errorf("progress = %v, want 0.5", evt.Progress)
+	}
+	if evt.Stats != nil {
+		t.Error("expected nil stats for basic progress event")
+	}
+}
+
+func TestSendProgressWithStats(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := NewWriter(rec)
+
+	stats := map[string]int{"clusters": 5}
+	if err := sw.SendProgressWithStats(StageSelection, 1.0, stats); err != nil {
+		t.Fatalf("SendProgressWithStats: %v", err)
+	}
+
+	data := extractData(t, rec.Body.String(), "progress")
+	var evt ProgressEvent
+	if err := json.Unmarshal([]byte(data), &evt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if evt.Stats == nil {
+		t.Fatal("expected non-nil stats")
+	}
+
+	var parsed map[string]int
+	if err := json.Unmarshal(*evt.Stats, &parsed); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	if parsed["clusters"] != 5 {
+		t.Errorf("clusters = %d, want 5", parsed["clusters"])
+	}
+}
+
+func TestSendComplete(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := NewWriter(rec)
+
+	chunks := []map[string]string{{"id": "a", "text": "hello"}}
+	stats := map[string]int{"input_count": 3, "output_count": 1}
+
+	if err := sw.SendComplete(chunks, stats); err != nil {
+		t.Fatalf("SendComplete: %v", err)
+	}
+
+	data := extractData(t, rec.Body.String(), "complete")
+	var evt CompleteEvent
+	if err := json.Unmarshal([]byte(data), &evt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	var parsedChunks []map[string]string
+	if err := json.Unmarshal(evt.Chunks, &parsedChunks); err != nil {
+		t.Fatalf("unmarshal chunks: %v", err)
+	}
+	if len(parsedChunks) != 1 || parsedChunks[0]["id"] != "a" {
+		t.Errorf("unexpected chunks: %v", parsedChunks)
+	}
+}
+
+func TestSendError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := NewWriter(rec)
+
+	if err := sw.SendError(StageEmbedding, "API key missing"); err != nil {
+		t.Fatalf("SendError: %v", err)
+	}
+
+	data := extractData(t, rec.Body.String(), "error")
+	var evt ErrorEvent
+	if err := json.Unmarshal([]byte(data), &evt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if evt.Error != "API key missing" {
+		t.Errorf("error = %q, want %q", evt.Error, "API key missing")
+	}
+	if evt.Stage != StageEmbedding {
+		t.Errorf("stage = %q, want %q", evt.Stage, StageEmbedding)
+	}
+}
+
+func TestMultipleEvents(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := NewWriter(rec)
+
+	_ = sw.SendProgress(StageEmbedding, 0)
+	_ = sw.SendProgress(StageEmbedding, 1.0)
+	_ = sw.SendProgress(StageClustering, 0)
+	_ = sw.SendProgress(StageClustering, 1.0)
+	_ = sw.SendComplete([]string{}, map[string]int{})
+
+	body := rec.Body.String()
+	progressCount := strings.Count(body, "event: progress")
+	if progressCount != 4 {
+		t.Errorf("progress events = %d, want 4", progressCount)
+	}
+	completeCount := strings.Count(body, "event: complete")
+	if completeCount != 1 {
+		t.Errorf("complete events = %d, want 1", completeCount)
+	}
+}
+
+func TestStageTimer(t *testing.T) {
+	timer := NewStageTimer(StageClustering)
+	time.Sleep(10 * time.Millisecond)
+
+	if timer.Stage != StageClustering {
+		t.Errorf("stage = %q, want %q", timer.Stage, StageClustering)
+	}
+	if timer.Elapsed() < 10*time.Millisecond {
+		t.Errorf("elapsed = %v, expected >= 10ms", timer.Elapsed())
+	}
+	if timer.ElapsedMs() < 10 {
+		t.Errorf("elapsed ms = %d, expected >= 10", timer.ElapsedMs())
+	}
+}
+
+func TestStageConstants(t *testing.T) {
+	stages := []Stage{StageEmbedding, StageClustering, StageSelection, StageCompress, StageMMR}
+	seen := make(map[Stage]bool)
+	for _, s := range stages {
+		if s == "" {
+			t.Error("empty stage constant")
+		}
+		if seen[s] {
+			t.Errorf("duplicate stage: %s", s)
+		}
+		seen[s] = true
+	}
+}
+
+// extractData finds the data line for the first occurrence of the given event type.
+func extractData(t *testing.T, body, eventType string) string {
+	t.Helper()
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if line == "event: "+eventType {
+			if i+1 < len(lines) && strings.HasPrefix(lines[i+1], "data: ") {
+				return strings.TrimPrefix(lines[i+1], "data: ")
+			}
+		}
+	}
+	t.Fatalf("no data found for event type %q in:\n%s", eventType, body)
+	return ""
+}


### PR DESCRIPTION
Adds `POST /v1/dedupe/stream` - a streaming variant of `/v1/dedupe` that sends Server-Sent Events as each pipeline stage completes.

## Motivation

Large dedup requests can take several seconds (especially with embedding generation). Streaming provides progress visibility and faster time-to-first-byte.

## SSE event protocol

```
event: progress
data: {"stage":"embedding","progress":0}

event: progress
data: {"stage":"embedding","progress":1}

event: progress
data: {"stage":"clustering","progress":1,"stats":{"clusters_formed":5,"input_count":12}}

event: progress
data: {"stage":"selection","progress":1,"stats":{"selected":5}}

event: complete
data: {"chunks":[...],"stats":{"input_count":12,"output_count":5,...}}
```

Three event types:
- `progress` - stage name, completion ratio (0-1), optional per-stage stats
- `complete` - final chunks + stats (same schema as `/v1/dedupe` response)
- `error` - stage + error message

## Usage

```bash
curl -N -X POST http://localhost:8080/v1/dedupe/stream \
  -H "Content-Type: application/json" \
  -d '{"chunks": [{"text": "..."}], "threshold": 0.15}'
```

```javascript
const es = new EventSource('/v1/dedupe/stream', { method: 'POST', body: ... });
es.addEventListener('progress', (e) => console.log(JSON.parse(e.data)));
es.addEventListener('complete', (e) => console.log(JSON.parse(e.data)));
```

## Changes

- `pkg/sse/sse.go` - SSE Writer with typed event methods (progress, complete, error), stage timer
- `pkg/sse/sse_test.go` - 9 unit tests
- `cmd/api.go` - New `/v1/dedupe/stream` route, streaming handler with per-stage events, tracing + metrics integration

Closes #6