### PR TITLE
Shell completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 # Build
 dist/
 build/
+completions

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@ version: 2
 
 before:
   hooks:
+    - ./scripts/completions.sh
     - go mod tidy
 
 builds:
@@ -28,6 +29,8 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - completions/*
 
 checksum:
   name_template: 'checksums.txt'

--- a/README.md
+++ b/README.md
@@ -213,6 +213,75 @@ distill query     # Test a query from command line
 distill config    # Manage configuration files
 ```
 
+## Shell Completions
+
+Distill can generate shell completion scripts for Bash, Zsh, Fish, and PowerShell.
+
+If you installed via GitHub Releases, the extracted archive includes pre-generated scripts under `completions/`.
+Otherwise, generate them using `distill completion <shell>`.
+
+### Zsh
+
+```sh
+mkdir -p ~/.zsh/completions
+distill completion zsh > ~/.zsh/completions/_distill
+```
+
+Add this to `~/.zshrc`:
+
+```zsh
+# Distill completions
+fpath=(~/.zsh/completions $fpath)
+autoload -Uz compinit && compinit
+```
+
+Reload:
+
+```sh
+exec zsh
+```
+
+### Bash
+
+```sh
+sudo mkdir -p /etc/bash_completion.d
+distill completion bash | sudo tee /etc/bash_completion.d/distill >/dev/null
+```
+
+Reload:
+
+```sh
+exec bash
+```
+
+### Fish
+
+```sh
+mkdir -p ~/.config/fish/completions
+distill completion fish > ~/.config/fish/completions/distill.fish
+exec fish
+```
+
+### PowerShell
+
+Add to your PowerShell profile:
+
+```powershell
+distill completion powershell | Out-String | Invoke-Expression
+```
+
+To open/edit your profile:
+
+```powershell
+notepad $PROFILE
+```
+
+### Quick verification
+
+```sh
+distill <TAB>
+```
+
 ## API Endpoints
 
 | Method | Path | Description |

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for Distill CLI.
+
+Bash:
+  $ distill completion bash > /etc/bash_completion.d/distill
+
+Zsh:
+  # Ensure completion is enabled in your .zshrc (autoload -Uz compinit; compinit)
+  $ distill completion zsh > "${fpath[1]}/_distill"
+
+Fish:
+  $ distill completion fish > ~/.config/fish/completions/distill.fish
+
+PowerShell:
+  PS> distill completion powershell | Out-String | Invoke-Expression
+`,
+	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+	Args:      cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletion(os.Stdout)
+
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		default:
+			return fmt.Errorf("unsupported shell: %s", args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,9 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	// Disable the default cobra completion command to avoid duplicate name conflict.
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.distill.yaml)")
 	rootCmd.PersistentFlags().Bool("verbose", false, "enable verbose output")

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+rm -rf completions
+mkdir -p completions
+
+# Generate shell completion scripts for all supported shells
+for sh in bash zsh fish powershell; do
+  go run . completion "$sh" > "completions/distill.$sh"
+done
+


### PR DESCRIPTION
**What this PR does:**
The PR adds `distill completion` command that generates shell completions for Bash, Zsh, Fish, and PowerShell.

**Which issue(s) this PR fixes:**
Fixes: #26 

**Checklist**
 - [x] cmd/completion.go - Completion command
 - [x] README section with installation instructions per shell
 - [x] GoReleaser: include completion scripts in release archives