### PR TITLE
fix: enable memory and session endpoints on Render deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     region: oregon
     plan: free
     buildCommand: go build -o distill .
-    startCommand: ./distill api --port $PORT
+    startCommand: ./distill api --port $PORT --memory --session
     envVars:
       - key: OPENAI_API_KEY
         sync: false  # Set manually in dashboard


### PR DESCRIPTION
The Render start command was `./distill api --port $PORT` — missing `--memory` and `--session` flags. This meant the hosted API at distill-api-4u92.onrender.com didn't register `/v1/memory/*` or `/v1/session/*` endpoints, causing the MCP server to get the info page instead of tool responses.

**Change:** `./distill api --port $PORT` → `./distill api --port $PORT --memory --session`

After merging, Render will auto-deploy and the hosted MCP server at distill-mcp.netlify.app will work end-to-end.