### PR TITLE
docs: add Agentic Engineering Guide reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Less redundant data. Lower costs. Faster responses. Deterministic results.
 
 **[Learn more →](https://distill.siddhantkhare.com)**
 
+> 📖 Distill implements the 4-layer context engineering stack (Cluster → Select → Rerank → Compress) described in **[The Agentic Engineering Guide](https://agents.siddhantkhare.com/05-context-engineering-stack/)** — a free, open book on AI agent infrastructure.
+
 ```
 Context sources → Distill → LLM
 (RAG, tools, memory, docs)    (reliable outputs)
@@ -819,6 +821,7 @@ For commercial licensing, contact: siddhantkhare2694@gmail.com
 
 - [Website](https://distill.siddhantkhare.com)
 - [Playground](https://distill.siddhantkhare.com/playground)
+- [The Agentic Engineering Guide](https://agents.siddhantkhare.com) — the book behind the concepts Distill implements
 - [FAQ](FAQ.md)
 - [Blog Post](https://dev.to/siddhantkcode/the-engineering-guide-to-context-window-efficiency-202b)
 - [MCP Configuration](mcp/README.md)


### PR DESCRIPTION
## Description

Add a reference to [The Agentic Engineering Guide](https://agents.siddhantkhare.com) in the README. Distill is already featured as the reference implementation in Chapter 5 (The Context Engineering Stack) — this links back from the repo to the book.

Two additions:
- Callout block near the top linking to Ch. 05
- Entry in the Links section at the bottom

## How to test

Visual — check the rendered README on the PR branch.

---
## EntelligenceAI PR Summary 
 This PR enriches the README.md with documentation references to 'The Agentic Engineering Guide' to provide context for Distill's context engineering stack.
- Added a callout block near the top of README.md introducing the 4-layer stack: Cluster → Select → Rerank → Compress
- Appended a link to 'The Agentic Engineering Guide' in the Resources section at the bottom of README.md 


---

## Confidence Score: 5/5 - Safe to Merge

- No review comments were generated, indicating the PR appears clean.
- Zero critical, significant, or medium issues identified by automated analysis.
- All heuristic indicators point to a safe merge with no blocking concerns.
