### PR TITLE
feat: add Makefile for common development tasks [superseded by #66]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+.PHONY: all build test lint clean bench fmt vet docker-build docker-run config-init install release-dry help
+
+all: build
+
+build:
+	go build -o distill .
+
+test:
+	go test ./...
+
+lint: 
+	golangci-lint run
+
+bench:
+	go test -bench=. -benchmem ./...
+
+fmt:
+	gofmt -w .
+
+vet:
+	go vet ./...
+
+clean:
+	rm -f distill
+
+docker-build:
+	docker build -t distill .
+
+docker-run:
+	docker run --rm -p 8080:8080 distill
+
+config-init:
+	./distill config init
+
+install:
+	go install
+
+release-dry:
+	goreleaser --snapshot --clean
+
+help:
+	@echo "Available targets:"
+	@echo "  build:		- Build the distill binary"
+	@echo "  test:			- Run all tests"
+	@echo "  lint:			- Run golangci-lint"
+	@echo "  bench:		- Run benchmarks"
+	@echo "  fmt:			- Format Go source files"
+	@echo "  vet:			- Run go vet"
+	@echo "  clean:		- Remove the distill binary"
+	@echo "  docker-build:		- Build the Docker image"
+	@echo "  docker-run:		- Run the Docker container and remove it after exit"
+	@echo "  config-init:		- Initialize the config file"
+	@echo "  install:		- Install the binary"
+	@echo "  release-dry:		- Dry run the release process"
+	@echo "  help:			- Show this help message"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,17 @@ docker run -p 8080:8080 -e OPENAI_API_KEY=your-key ghcr.io/siddhant-k-code/disti
 ```bash
 git clone https://github.com/Siddhant-K-code/distill.git
 cd distill
-go build -o distill .
+make build
+```
+
+Common development targets:
+
+```bash
+make test       # Run all tests
+make lint       # Run golangci-lint
+make bench      # Run benchmarks
+make fmt        # Format source files
+make help       # List all available targets
 ```
 
 ## Quick Start
@@ -807,8 +817,9 @@ Contributions welcome! Check the [open issues](https://github.com/Siddhant-K-cod
 ```bash
 git clone https://github.com/Siddhant-K-code/distill.git
 cd distill
-go build -o distill .
-go test ./...
+make build
+make test
+make lint
 ```
 
 ## License


### PR DESCRIPTION
Superseded by #66 which was merged with an expanded Makefile (20+ targets). Closing this older version.