### PR TITLE
feat(cache): PatternDetector emits cache_control annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,8 +645,27 @@ Token-budgeted context windows for long-running tasks. Entries are deduplicated 
 KV cache for repeated context patterns (system prompts, tool definitions, boilerplate). Sub-millisecond retrieval for cache hits.
 
 - **MemoryCache** - In-memory LRU with TTL, configurable size limits (entries and bytes), background cleanup
-- **PatternDetector** - Identifies cacheable content: system prompts, tool/function definitions, code blocks
+- **PatternDetector** - Identifies cacheable content and emits `CacheAnnotation` per chunk. Use `AnnotateChunksForCache` to get a `CacheControlPlan` — up to 4 `cache_control` markers (Anthropic's limit) placed at the highest-token-count stable chunks. Auto-placement is skipped when the caller has already set markers manually.
 - **RedisCache** - Interface for distributed deployments (requires external Redis)
+
+#### Automatic cache_control placement
+
+```go
+detector := cache.NewPatternDetector()
+plan := detector.AnnotateChunksForCache(chunks)
+// plan.Markers lists which chunk indices should receive cache_control markers
+// plan.ManualMarkersPresent is true if the caller already placed markers
+```
+
+Pattern → annotation mapping:
+
+| Pattern | Recommended | Condition |
+|---------|-------------|-----------|
+| `system_prompt` | Yes | Always |
+| `tool_definition` | Yes | Always |
+| `code_block` | Conditional | Token count ≥ 512 |
+| `document` | Yes | Always |
+| `user_message` | No | Dynamic per turn |
 
 ## Architecture
 
@@ -708,6 +727,7 @@ Distill is evolving from a dedup utility into a context intelligence layer. Here
 |---------|-------|--------|-------------|
 | **Context Memory Store** | [#29](https://github.com/Siddhant-K-code/distill/issues/29) | Shipped | Persistent, deduplicated memory across sessions. Write-time dedup, hierarchical decay, token-budgeted recall. See [Context Memory](#context-memory). |
 | **Session Management** | [#31](https://github.com/Siddhant-K-code/distill/issues/31) | Shipped | Stateful context windows with token budgets, hierarchical compression, and importance-based eviction. See [Session Management](#session-management). |
+| **PatternDetector cache_control annotations** | [#53](https://github.com/Siddhant-K-code/distill/issues/53) | Shipped | `PatternDetector` emits `CacheAnnotation` per chunk and `AnnotateChunksForCache` produces a `CacheControlPlan` with up to 4 Anthropic-compatible markers. |
 
 ### Code Intelligence
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -267,6 +269,105 @@ func TestPatternDetector_DetectPattern(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPatternDetector_CacheAnnotation(t *testing.T) {
+	detector := NewPatternDetector()
+
+	tests := []struct {
+		name            string
+		text            string
+		wantRecommended bool
+		wantReason      string
+	}{
+		{
+			name:            "system prompt gets cache annotation",
+			text:            "You are a helpful AI assistant that helps users with coding tasks. Be concise and accurate in all responses.",
+			wantRecommended: true,
+			wantReason:      "system_prompt",
+		},
+		{
+			name:            "tool definition gets cache annotation",
+			text:            `{"type": "function", "function": {"name": "search", "description": "Search the web for information", "parameters": {"type": "object"}}}`,
+			wantRecommended: true,
+			wantReason:      "tool_definition",
+		},
+		{
+			name:            "document gets cache annotation",
+			text:            "This is a regular document with some information about the product and its features for users.",
+			wantRecommended: true,
+			wantReason:      "document",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := detector.DetectPattern(tt.text)
+			if p == nil {
+				t.Fatal("expected pattern, got nil")
+			}
+			if p.CacheAnnotation == nil {
+				t.Fatal("expected CacheAnnotation, got nil")
+			}
+			if p.CacheAnnotation.Recommended != tt.wantRecommended {
+				t.Errorf("Recommended: got %v, want %v", p.CacheAnnotation.Recommended, tt.wantRecommended)
+			}
+			if p.CacheAnnotation.Reason != tt.wantReason {
+				t.Errorf("Reason: got %q, want %q", p.CacheAnnotation.Reason, tt.wantReason)
+			}
+			if p.TokenCount <= 0 {
+				t.Error("expected positive TokenCount")
+			}
+		})
+	}
+}
+
+func TestPatternDetector_AnnotateChunksForCache(t *testing.T) {
+	detector := NewPatternDetector()
+
+	t.Run("selects up to 4 markers by token count", func(t *testing.T) {
+		// Build 5 system-prompt-like chunks of varying sizes.
+		chunks := make([]types.Chunk, 5)
+		for i := range chunks {
+			size := (i + 1) * 300 // 300, 600, 900, 1200, 1500 chars
+			text := "You are a helpful assistant. " + strings.Repeat("x", size)
+			chunks[i] = types.Chunk{ID: fmt.Sprintf("%d", i), Text: text}
+		}
+
+		plan := detector.AnnotateChunksForCache(chunks)
+		if plan.ManualMarkersPresent {
+			t.Error("expected no manual markers")
+		}
+		if len(plan.Markers) > maxCacheMarkers {
+			t.Errorf("expected at most %d markers, got %d", maxCacheMarkers, len(plan.Markers))
+		}
+	})
+
+	t.Run("skips auto-placement when manual markers present", func(t *testing.T) {
+		chunks := []types.Chunk{
+			{
+				ID:   "1",
+				Text: "You are a helpful assistant with many capabilities.",
+				Metadata: map[string]interface{}{
+					"cache_control": "ephemeral",
+				},
+			},
+		}
+		plan := detector.AnnotateChunksForCache(chunks)
+		if !plan.ManualMarkersPresent {
+			t.Error("expected ManualMarkersPresent=true")
+		}
+		if len(plan.Markers) != 0 {
+			t.Errorf("expected 0 markers when manual markers present, got %d", len(plan.Markers))
+		}
+	})
+
+	t.Run("empty chunks returns empty plan", func(t *testing.T) {
+		plan := detector.AnnotateChunksForCache(nil)
+		if len(plan.Markers) != 0 {
+			t.Errorf("expected 0 markers for nil input, got %d", len(plan.Markers))
+		}
+	})
 }
 
 func TestPatternDetector_DetectChunkPatterns(t *testing.T) {

--- a/pkg/cache/patterns.go
+++ b/pkg/cache/patterns.go
@@ -50,22 +50,49 @@ func NewPatternDetector() *PatternDetector {
 type PatternType string
 
 const (
-	PatternTypeUnknown    PatternType = "unknown"
-	PatternTypeSystem     PatternType = "system_prompt"
-	PatternTypeTool       PatternType = "tool_definition"
-	PatternTypeCode       PatternType = "code_block"
-	PatternTypeDocument   PatternType = "document"
+	PatternTypeUnknown  PatternType = "unknown"
+	PatternTypeSystem   PatternType = "system_prompt"
+	PatternTypeTool     PatternType = "tool_definition"
+	PatternTypeCode     PatternType = "code_block"
+	PatternTypeDocument PatternType = "document"
 )
+
+// minCacheableTokens is Anthropic's minimum prefix size to qualify for caching.
+const minCacheableTokens = 1024
+
+// maxCacheMarkers is the maximum number of simultaneous cache_control markers
+// Anthropic allows per request.
+const maxCacheMarkers = 4
+
+// CacheAnnotation describes whether and how a chunk should receive a
+// cache_control marker before being sent to the Anthropic API.
+type CacheAnnotation struct {
+	// Recommended is true when a cache_control marker should be placed after
+	// this chunk.
+	Recommended bool
+
+	// Reason is a short label explaining why caching is recommended.
+	Reason string
+
+	// MinTokensMet is true when the chunk meets Anthropic's 1024-token minimum.
+	MinTokensMet bool
+
+	// BoundaryAfter indicates the marker should be placed after this chunk.
+	BoundaryAfter bool
+}
 
 // DetectedPattern represents a detected cacheable pattern.
 type DetectedPattern struct {
-	Type     PatternType
-	Hash     string
-	Text     string
-	Metadata map[string]string
+	Type            PatternType
+	Hash            string
+	Text            string
+	TokenCount      int
+	CacheAnnotation *CacheAnnotation
+	Metadata        map[string]string
 }
 
-// DetectPattern analyzes text and returns pattern information.
+// DetectPattern analyzes text and returns pattern information including a
+// cache annotation indicating whether a cache_control marker is recommended.
 func (d *PatternDetector) DetectPattern(text string) *DetectedPattern {
 	if len(text) < d.MinLength {
 		return nil
@@ -73,16 +100,22 @@ func (d *PatternDetector) DetectPattern(text string) *DetectedPattern {
 
 	lower := strings.ToLower(text)
 	patternType := d.classifyPattern(lower, text)
+	tokens := estimateTokens(text)
 
-	return &DetectedPattern{
-		Type:     patternType,
-		Hash:     HashText(text),
-		Text:     text,
-		Metadata: make(map[string]string),
+	p := &DetectedPattern{
+		Type:       patternType,
+		Hash:       HashText(text),
+		Text:       text,
+		TokenCount: tokens,
+		Metadata:   make(map[string]string),
 	}
+	p.CacheAnnotation = d.annotate(patternType, tokens, text)
+	return p
 }
 
 // DetectChunkPatterns analyzes chunks and returns cacheable patterns.
+// The returned slice is ordered by token count descending so callers can
+// trivially apply the maxCacheMarkers limit.
 func (d *PatternDetector) DetectChunkPatterns(chunks []types.Chunk) []DetectedPattern {
 	var patterns []DetectedPattern
 
@@ -94,6 +127,137 @@ func (d *PatternDetector) DetectChunkPatterns(chunks []types.Chunk) []DetectedPa
 	}
 
 	return patterns
+}
+
+// AnnotateChunksForCache walks chunks in order, applies cache_control
+// annotations, and returns a CacheControlPlan describing which chunk indices
+// should receive a marker. At most maxCacheMarkers markers are placed; when
+// more candidates exist the ones with the highest token counts are chosen.
+//
+// If any chunk already carries a manual cache_control marker (indicated by
+// the "cache_control" key in its Metadata), auto-placement is skipped and
+// the existing markers are returned as-is.
+func (d *PatternDetector) AnnotateChunksForCache(chunks []types.Chunk) CacheControlPlan {
+	// Respect manually placed markers.
+	for _, c := range chunks {
+		if _, ok := c.Metadata["cache_control"]; ok {
+			return CacheControlPlan{ManualMarkersPresent: true}
+		}
+	}
+
+	type candidate struct {
+		index  int
+		tokens int
+		reason string
+	}
+	var candidates []candidate
+
+	for i, chunk := range chunks {
+		p := d.DetectPattern(chunk.Text)
+		if p == nil || p.CacheAnnotation == nil || !p.CacheAnnotation.Recommended {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			index:  i,
+			tokens: p.TokenCount,
+			reason: p.CacheAnnotation.Reason,
+		})
+	}
+
+	// Select up to maxCacheMarkers by highest token count.
+	if len(candidates) > maxCacheMarkers {
+		// Partial sort: keep the top maxCacheMarkers by token count.
+		for i := 0; i < maxCacheMarkers; i++ {
+			best := i
+			for j := i + 1; j < len(candidates); j++ {
+				if candidates[j].tokens > candidates[best].tokens {
+					best = j
+				}
+			}
+			candidates[i], candidates[best] = candidates[best], candidates[i]
+		}
+		candidates = candidates[:maxCacheMarkers]
+	}
+
+	plan := CacheControlPlan{}
+	for _, c := range candidates {
+		plan.Markers = append(plan.Markers, CacheMarker{
+			ChunkIndex: c.index,
+			Reason:     c.reason,
+			Tokens:     c.tokens,
+		})
+	}
+	return plan
+}
+
+// CacheControlPlan describes where cache_control markers should be placed.
+type CacheControlPlan struct {
+	// Markers lists the chunks that should receive a cache_control marker.
+	Markers []CacheMarker
+
+	// ManualMarkersPresent is true when the caller has already placed
+	// cache_control markers; auto-placement was skipped.
+	ManualMarkersPresent bool
+}
+
+// CacheMarker identifies a single cache_control placement.
+type CacheMarker struct {
+	// ChunkIndex is the position in the chunks slice.
+	ChunkIndex int
+
+	// Reason is a short label for why this chunk was selected.
+	Reason string
+
+	// Tokens is the token count of the chunk.
+	Tokens int
+}
+
+// annotate builds a CacheAnnotation for the given pattern type and token count.
+func (d *PatternDetector) annotate(pt PatternType, tokens int, text string) *CacheAnnotation {
+	minMet := tokens >= minCacheableTokens
+
+	switch pt {
+	case PatternTypeSystem:
+		return &CacheAnnotation{
+			Recommended:   true,
+			Reason:        "system_prompt",
+			MinTokensMet:  minMet,
+			BoundaryAfter: true,
+		}
+	case PatternTypeTool:
+		return &CacheAnnotation{
+			Recommended:   true,
+			Reason:        "tool_definition",
+			MinTokensMet:  minMet,
+			BoundaryAfter: true,
+		}
+	case PatternTypeCode:
+		// Only recommend caching for large code blocks in the first 60% of
+		// the text (heuristic: position unknown here, so use token count only).
+		recommended := tokens >= 512
+		return &CacheAnnotation{
+			Recommended:   recommended,
+			Reason:        "stable_code_block",
+			MinTokensMet:  minMet,
+			BoundaryAfter: true,
+		}
+	case PatternTypeDocument:
+		// Boilerplate / repetitive documents benefit from caching.
+		return &CacheAnnotation{
+			Recommended:   true,
+			Reason:        "document",
+			MinTokensMet:  minMet,
+			BoundaryAfter: true,
+		}
+	default:
+		return &CacheAnnotation{Recommended: false}
+	}
+}
+
+// estimateTokens approximates the token count of text using the common
+// 4-chars-per-token heuristic.
+func estimateTokens(text string) int {
+	return (len(text) + 3) / 4
 }
 
 // classifyPattern determines the pattern type.


### PR DESCRIPTION
Closes #53

## What

Extends `PatternDetector` in `pkg/cache` to output a `CacheAnnotation` alongside each pattern classification, and adds `AnnotateChunksForCache` to produce a `CacheControlPlan` for a chunk slice.

## Changes

**`pkg/cache/patterns.go`**
- `CacheAnnotation` struct: `Recommended`, `Reason`, `MinTokensMet`, `BoundaryAfter`
- `DetectedPattern` now carries `TokenCount` and `CacheAnnotation`
- `annotate()`: pattern → annotation mapping
  - `system_prompt`, `tool_definition`, `document` → always recommended
  - `code_block` → conditional on token count ≥ 512
  - user messages → not recommended
- `AnnotateChunksForCache(chunks)`: walks chunks, selects up to 4 markers (Anthropic's limit) by highest token count, skips auto-placement when manual `cache_control` markers are already present in chunk metadata
- `CacheControlPlan` / `CacheMarker` types

**`pkg/cache/cache_test.go`**
- `TestPatternDetector_CacheAnnotation`: verifies annotation per pattern type
- `TestPatternDetector_AnnotateChunksForCache`: 4-marker cap, manual marker passthrough, nil input

## Why

`PatternDetector` already identifies cacheable content (system prompts, tool definitions, code blocks). This change connects that signal to Anthropic's `cache_control` field so callers get correct markers without needing to understand prompt caching mechanics. It also provides stability hints to the session-aware boundary manager (issue #51).
