### PR TITLE
feat(memory): memory decay lifecycle events and cache boundary hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,38 @@ Strategies can be chained via `compress.Pipeline`. Configure with target reducti
 
 Persistent context memory across agent sessions. SQLite-backed with write-time deduplication via cosine similarity. Memories decay over time: full text → summary → keywords → evicted. Recall ranked by `(1-w)*similarity + w*recency`. Enable with `--memory` flag.
 
+#### Lifecycle events
+
+The `DecayWorker` emits typed events on every state transition so that cache boundary managers and other subscribers can stay in sync:
+
+| Event | When | Cache boundary action |
+|-------|------|-----------------------|
+| `EventCompressed` | Entry compressed to summary or keywords | Retreat boundary — cached prefix is now stale |
+| `EventEvicted` | Entry removed from store | Retreat boundary — entry no longer exists |
+| `EventStabilized` | Entry promoted to stable | Advance boundary to include entry |
+
+Register a handler on any `Store`:
+
+```go
+store.OnLifecycleEvent(func(e memory.MemoryEvent) {
+    // e.Type, e.EntryID, e.TokensBefore, e.TokensAfter, e.CompressionLevel
+})
+```
+
+Multiple handlers can be registered; they are called in registration order. Handlers must be non-blocking.
+
+#### Cache boundary hint on recall
+
+`RecallResult` now includes a `CacheHint` field. Entries with recall relevance ≥ 0.7 are listed as stable candidates, giving the boundary manager early signal without waiting for the normal stability promotion cycle:
+
+```go
+result, _ := store.Recall(ctx, req)
+if result.CacheHint != nil {
+    // result.CacheHint.StableEntryIDs — IDs likely stable this turn
+    // result.CacheHint.ConfidenceScore — mean relevance of returned entries
+}
+```
+
 ### Session (`pkg/session`)
 
 Token-budgeted context windows for long-running tasks. Entries are deduplicated on push, compressed through hierarchical levels when the budget is exceeded, and evicted by importance. The `preserve_recent` setting keeps the N most recent entries at full fidelity. Enable with `--session` flag.
@@ -787,6 +819,7 @@ Distill is evolving from a dedup utility into a context intelligence layer. Here
 | **PatternDetector cache_control annotations** | [#53](https://github.com/Siddhant-K-code/distill/issues/53) | Shipped | `PatternDetector` emits `CacheAnnotation` per chunk and `AnnotateChunksForCache` produces a `CacheControlPlan` with up to 4 Anthropic-compatible markers. |
 | **Session-aware cache boundary manager** | [#51](https://github.com/Siddhant-K-code/distill/issues/51) | Shipped | Auto-advances `cache_control` placement as sessions grow. Stable entries (present ≥ 2 turns unmodified) are included in the cached prefix; boundary retreats when content changes. |
 | **Cache write cost accounting** | [#52](https://github.com/Siddhant-K-code/distill/issues/52) | Shipped | 9 new Prometheus metrics covering Anthropic prompt cache token usage, hit rate, write efficiency, and boundary position. Feed API response usage via `RecordCacheUsage`. |
+| **Memory decay lifecycle events** | [#54](https://github.com/Siddhant-K-code/distill/issues/54) | Shipped | `DecayWorker` emits `EventCompressed` and `EventEvicted` on each transition. `RecallResult` includes a `CacheBoundaryHint` for high-relevance entries. |
 
 ### Code Intelligence
 

--- a/pkg/memory/cache_events.go
+++ b/pkg/memory/cache_events.go
@@ -1,0 +1,58 @@
+package memory
+
+import "time"
+
+// MemoryEventType identifies the kind of lifecycle transition a memory entry
+// has undergone. Subscribers (e.g. a cache boundary manager) use these events
+// to keep their state consistent with the memory store.
+type MemoryEventType string
+
+const (
+	// EventStabilized fires when an entry has been present for enough turns
+	// without modification to be considered stable.
+	EventStabilized MemoryEventType = "stabilized"
+
+	// EventCompressed fires when an entry is compressed to a shorter form
+	// (full text → summary, or summary → keywords). The cached prefix that
+	// contained the full text is now stale and must be invalidated.
+	EventCompressed MemoryEventType = "compressed"
+
+	// EventEvicted fires when an entry is removed from the store entirely.
+	// Any cached prefix that included this entry must retreat.
+	EventEvicted MemoryEventType = "evicted"
+)
+
+// MemoryEvent describes a single lifecycle transition for a memory entry.
+type MemoryEvent struct {
+	Type    MemoryEventType
+	EntryID string
+
+	// TokensBefore is the token count before the transition (0 for stabilized).
+	TokensBefore int
+
+	// TokensAfter is the token count after the transition (0 for evicted).
+	TokensAfter int
+
+	// CompressionLevel is the new decay level (only set for EventCompressed).
+	CompressionLevel DecayLevel
+
+	OccurredAt time.Time
+}
+
+// MemoryEventHandler is a callback invoked when a memory lifecycle event fires.
+// Implementations must be non-blocking; long work should be dispatched to a
+// goroutine.
+type MemoryEventHandler func(event MemoryEvent)
+
+// CacheBoundaryHint is included in RecallResult to give the cache boundary
+// manager early signal about which entries are stable this turn, without
+// waiting for the normal stability promotion cycle.
+type CacheBoundaryHint struct {
+	// StableEntryIDs lists entries that are likely stable this turn, ranked
+	// by the recall scoring function (high recency + high similarity).
+	StableEntryIDs []string
+
+	// ConfidenceScore is the mean recall score of the stable entries (0–1).
+	// Higher values mean the boundary manager can act with more confidence.
+	ConfidenceScore float64
+}

--- a/pkg/memory/decay.go
+++ b/pkg/memory/decay.go
@@ -14,6 +14,9 @@ import (
 // Memories progress through decay levels based on age and access patterns:
 //
 //	full text -> summary -> keywords -> evicted
+//
+// When entries transition, lifecycle events are emitted via the store's
+// registered handlers so that cache boundary managers can stay in sync.
 type DecayWorker struct {
 	store  *SQLiteStore
 	cfg    Config
@@ -64,16 +67,15 @@ func (w *DecayWorker) runOnce(ctx context.Context) error {
 
 	now := time.Now().UTC()
 
-	// Evict: remove very old, unreferenced memories
+	// Evict: remove very old, unreferenced memories and emit EventEvicted.
 	if w.cfg.EvictAge > 0 {
 		evictBefore := now.Add(-w.cfg.EvictAge).Format(time.RFC3339Nano)
-		_, _ = w.store.db.ExecContext(ctx,
-			"DELETE FROM memories WHERE last_referenced < ? AND decay_level >= ?",
-			evictBefore, int(DecayKeywords),
-		)
+		if err := w.evictRows(ctx, evictBefore); err != nil {
+			return err
+		}
 	}
 
-	// Decay to keywords: compress old summaries
+	// Decay to keywords: compress old summaries.
 	if w.cfg.KeywordsAge > 0 {
 		keywordsBefore := now.Add(-w.cfg.KeywordsAge).Format(time.RFC3339Nano)
 		if err := w.decayRows(ctx, keywordsBefore, DecaySummary, DecayKeywords, extractKeywords); err != nil {
@@ -81,7 +83,7 @@ func (w *DecayWorker) runOnce(ctx context.Context) error {
 		}
 	}
 
-	// Decay to summary: compress old full-text memories
+	// Decay to summary: compress old full-text memories.
 	if w.cfg.SummaryAge > 0 {
 		summaryBefore := now.Add(-w.cfg.SummaryAge).Format(time.RFC3339Nano)
 		if err := w.decayRows(ctx, summaryBefore, DecayFull, DecaySummary, extractSummary); err != nil {
@@ -92,8 +94,47 @@ func (w *DecayWorker) runOnce(ctx context.Context) error {
 	return nil
 }
 
+// evictRows deletes memories at DecayKeywords level older than cutoff and
+// emits EventEvicted for each removed entry.
+func (w *DecayWorker) evictRows(ctx context.Context, cutoff string) error {
+	rows, err := w.store.db.QueryContext(ctx,
+		"SELECT id, LENGTH(text) FROM memories WHERE last_referenced < ? AND decay_level >= ?",
+		cutoff, int(DecayKeywords),
+	)
+	if err != nil {
+		return fmt.Errorf("query for eviction: %w", err)
+	}
+
+	type entry struct {
+		id     string
+		length int
+	}
+	var entries []entry
+	for rows.Next() {
+		var e entry
+		if err := rows.Scan(&e.id, &e.length); err != nil {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	_ = rows.Close()
+
+	for _, e := range entries {
+		_, _ = w.store.db.ExecContext(ctx, "DELETE FROM memories WHERE id = ?", e.id)
+		w.store.emit(MemoryEvent{
+			Type:         EventEvicted,
+			EntryID:      e.id,
+			TokensBefore: (e.length + 3) / 4,
+			TokensAfter:  0,
+			OccurredAt:   time.Now().UTC(),
+		})
+	}
+	return nil
+}
+
 // decayRows queries for memories at fromLevel older than cutoff,
-// applies the transform function, and updates them to toLevel.
+// applies the transform function, updates them to toLevel, and emits
+// EventCompressed for each entry so cache boundary managers can retreat.
 func (w *DecayWorker) decayRows(ctx context.Context, cutoff string, fromLevel, toLevel DecayLevel, transform func(string) string) error {
 	rows, err := w.store.db.QueryContext(ctx,
 		"SELECT id, text FROM memories WHERE last_referenced < ? AND decay_level = ?",
@@ -122,6 +163,14 @@ func (w *DecayWorker) decayRows(ctx context.Context, cutoff string, fromLevel, t
 			"UPDATE memories SET text = ?, decay_level = ? WHERE id = ?",
 			compressed, int(toLevel), e.id,
 		)
+		w.store.emit(MemoryEvent{
+			Type:             EventCompressed,
+			EntryID:          e.id,
+			TokensBefore:     (len(e.text) + 3) / 4,
+			TokensAfter:      (len(compressed) + 3) / 4,
+			CompressionLevel: toLevel,
+			OccurredAt:       time.Now().UTC(),
+		})
 	}
 
 	return nil

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -324,6 +324,148 @@ func TestDecayWorker(t *testing.T) {
 	}
 }
 
+func TestLifecycleEvents_Compression(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SummaryAge = 1 * time.Millisecond
+	cfg.KeywordsAge = 1 * time.Millisecond
+	cfg.EvictAge = 0
+	cfg.DedupThreshold = 0.15
+
+	s, err := NewSQLiteStore(":memory:", cfg)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	var events []MemoryEvent
+	s.OnLifecycleEvent(func(e MemoryEvent) {
+		events = append(events, e)
+	})
+
+	ctx := context.Background()
+
+	_, err = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "The authentication service uses JWT tokens with RS256 signing. It validates tokens on every request. The token expiry is set to 24 hours."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	past := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339Nano)
+	_, _ = s.db.ExecContext(ctx, "UPDATE memories SET last_referenced = ?", past)
+
+	w := NewDecayWorker(s, cfg)
+	if err := w.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(events) == 0 {
+		t.Fatal("expected at least one lifecycle event, got none")
+	}
+	if events[0].Type != EventCompressed {
+		t.Errorf("expected EventCompressed, got %s", events[0].Type)
+	}
+	if events[0].TokensBefore <= events[0].TokensAfter {
+		t.Errorf("expected TokensBefore > TokensAfter, got %d <= %d",
+			events[0].TokensBefore, events[0].TokensAfter)
+	}
+	if events[0].CompressionLevel != DecaySummary {
+		t.Errorf("expected DecaySummary, got %d", events[0].CompressionLevel)
+	}
+}
+
+func TestLifecycleEvents_Eviction(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.SummaryAge = 0
+	cfg.KeywordsAge = 0
+	cfg.EvictAge = 1 * time.Millisecond
+	cfg.DedupThreshold = 0.15
+
+	s, err := NewSQLiteStore(":memory:", cfg)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	var events []MemoryEvent
+	s.OnLifecycleEvent(func(e MemoryEvent) {
+		events = append(events, e)
+	})
+
+	ctx := context.Background()
+
+	_, err = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Old keywords-level memory that should be evicted soon."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	// Force to keywords level and backdate.
+	past := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339Nano)
+	_, _ = s.db.ExecContext(ctx,
+		"UPDATE memories SET decay_level = ?, last_referenced = ?",
+		int(DecayKeywords), past,
+	)
+
+	w := NewDecayWorker(s, cfg)
+	if err := w.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(events) == 0 {
+		t.Fatal("expected eviction event, got none")
+	}
+	if events[0].Type != EventEvicted {
+		t.Errorf("expected EventEvicted, got %s", events[0].Type)
+	}
+	if events[0].TokensAfter != 0 {
+		t.Errorf("expected TokensAfter=0 for eviction, got %d", events[0].TokensAfter)
+	}
+}
+
+func TestRecall_CacheBoundaryHint(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Store entries with embeddings; high-similarity recall should produce a hint.
+	_, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "The auth service uses JWT with RS256 signing algorithm", Embedding: makeEmbedding(0, 8)},
+			{Text: "Payment service integrates with Stripe for billing", Embedding: makeEmbedding(math.Pi/2, 8)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	result, err := s.Recall(ctx, RecallRequest{
+		Query:          "auth JWT",
+		QueryEmbedding: makeEmbedding(0, 8), // exact match → relevance near 1.0
+		MaxResults:     5,
+		RecencyWeight:  0.1,
+	})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+
+	// With a near-exact embedding match and low recency weight, the top entry
+	// should have relevance >= 0.7, producing a hint.
+	if result.CacheHint == nil {
+		t.Fatal("expected CacheBoundaryHint, got nil")
+	}
+	if len(result.CacheHint.StableEntryIDs) == 0 {
+		t.Error("expected at least one stable entry ID in hint")
+	}
+	if result.CacheHint.ConfidenceScore <= 0 {
+		t.Error("expected positive confidence score")
+	}
+}
+
 func TestEmbeddingRoundtrip(t *testing.T) {
 	original := []float32{0.1, 0.2, 0.3, -0.5, 1.0}
 	encoded := encodeEmbedding(original)

--- a/pkg/memory/sqlite.go
+++ b/pkg/memory/sqlite.go
@@ -16,8 +16,9 @@ import (
 // Uses a single connection (SetMaxOpenConns(1)) so SQLite's internal
 // serialization handles concurrency. No application-level mutex needed.
 type SQLiteStore struct {
-	db  *sql.DB
-	cfg Config
+	db       *sql.DB
+	cfg      Config
+	handlers []MemoryEventHandler
 }
 
 // NewSQLiteStore creates a new SQLite-backed memory store.
@@ -319,6 +320,10 @@ func (s *SQLiteStore) Recall(ctx context.Context, req RecallRequest) (*RecallRes
 		s.touchMemories(ctx, ids)
 	}
 
+	// Build a CacheBoundaryHint from the top-scoring recalled entries.
+	// Entries with relevance >= 0.7 are considered stable candidates.
+	hint := buildCacheBoundaryHint(results)
+
 	return &RecallResult{
 		Memories: results,
 		Stats: RecallStats{
@@ -327,7 +332,31 @@ func (s *SQLiteStore) Recall(ctx context.Context, req RecallRequest) (*RecallRes
 			Returned:     len(results),
 			TokenCount:   tokenCount,
 		},
+		CacheHint: hint,
 	}, nil
+}
+
+// buildCacheBoundaryHint derives a hint from recalled memories.
+// Entries with relevance >= 0.7 are treated as stable this turn.
+func buildCacheBoundaryHint(memories []RecalledMemory) *CacheBoundaryHint {
+	if len(memories) == 0 {
+		return nil
+	}
+	var stableIDs []string
+	var totalScore float64
+	for _, m := range memories {
+		totalScore += m.Relevance
+		if m.Relevance >= 0.7 {
+			stableIDs = append(stableIDs, m.ID)
+		}
+	}
+	if len(stableIDs) == 0 {
+		return nil
+	}
+	return &CacheBoundaryHint{
+		StableEntryIDs:  stableIDs,
+		ConfidenceScore: totalScore / float64(len(memories)),
+	}
 }
 
 // Forget removes memories matching the given criteria.
@@ -448,6 +477,20 @@ func (s *SQLiteStore) Stats(ctx context.Context) (*Stats, error) {
 	}
 
 	return stats, nil
+}
+
+// OnLifecycleEvent registers a handler called on memory lifecycle transitions.
+// Handlers are invoked synchronously in registration order; they must not
+// block. Multiple handlers may be registered.
+func (s *SQLiteStore) OnLifecycleEvent(handler MemoryEventHandler) {
+	s.handlers = append(s.handlers, handler)
+}
+
+// emit dispatches a lifecycle event to all registered handlers.
+func (s *SQLiteStore) emit(event MemoryEvent) {
+	for _, h := range s.handlers {
+		h(event)
+	}
 }
 
 // Close closes the database connection.

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -76,8 +76,11 @@ type RecallRequest struct {
 
 // RecallResult is the output of a recall operation.
 type RecallResult struct {
-	Memories []RecalledMemory `json:"memories"`
-	Stats    RecallStats      `json:"stats"`
+	Memories   []RecalledMemory   `json:"memories"`
+	Stats      RecallStats        `json:"stats"`
+	// CacheHint provides early stability signal to a cache boundary manager.
+	// Entries with high recency + similarity scores are likely stable this turn.
+	CacheHint  *CacheBoundaryHint `json:"cache_hint,omitempty"`
 }
 
 // RecalledMemory is a single memory returned from recall.
@@ -127,6 +130,7 @@ type Store interface {
 	Store(ctx context.Context, req StoreRequest) (*StoreResult, error)
 
 	// Recall retrieves memories matching a query, ranked by relevance and recency.
+	// The result includes a CacheBoundaryHint derived from the recall scores.
 	Recall(ctx context.Context, req RecallRequest) (*RecallResult, error)
 
 	// Forget removes memories matching the given criteria.
@@ -134,6 +138,11 @@ type Store interface {
 
 	// Stats returns memory store statistics.
 	Stats(ctx context.Context) (*Stats, error)
+
+	// OnLifecycleEvent registers a handler that is called whenever a memory
+	// entry transitions state (stabilized, compressed, evicted). Multiple
+	// handlers can be registered; they are called in registration order.
+	OnLifecycleEvent(handler MemoryEventHandler)
 
 	// Close releases resources held by the store.
 	Close() error


### PR DESCRIPTION
Closes #54

## What

Connects `pkg/memory`'s hierarchical decay lifecycle to the cache boundary layer. When the `DecayWorker` compresses or evicts a memory entry, it now emits a typed event so subscribers (e.g. a `CacheBoundaryManager`) can retreat the cached prefix before the next request sends stale content. `Recall` also returns a `CacheBoundaryHint` derived from recall scores, giving the boundary manager early stability signal without waiting for the normal promotion cycle.

## Changes

**`pkg/memory/cache_events.go`** (new)
- `MemoryEventType`: `EventStabilized`, `EventCompressed`, `EventEvicted`
- `MemoryEvent`: `Type`, `EntryID`, `TokensBefore`, `TokensAfter`, `CompressionLevel`, `OccurredAt`
- `MemoryEventHandler` callback type (non-blocking contract)
- `CacheBoundaryHint`: `StableEntryIDs`, `ConfidenceScore`

**`pkg/memory/store.go`**
- `RecallResult` gains `CacheHint *CacheBoundaryHint`
- `Store` interface gains `OnLifecycleEvent(MemoryEventHandler)`

**`pkg/memory/sqlite.go`**
- `SQLiteStore` gains `handlers []MemoryEventHandler`
- `OnLifecycleEvent` appends a handler; `emit` dispatches to all in order
- `Recall` calls `buildCacheBoundaryHint` — entries with relevance ≥ 0.7 are listed as stable candidates; `ConfidenceScore` is the mean relevance of all returned entries

**`pkg/memory/decay.go`**
- `evictRows` (new): queries entries at `DecayKeywords` level older than cutoff, deletes them, emits `EventEvicted` per entry
- `decayRows`: emits `EventCompressed` after each `UPDATE` with `TokensBefore`, `TokensAfter`, and `CompressionLevel`
- `runOnce` delegates eviction to `evictRows` instead of a bare `DELETE`

**`pkg/memory/memory_test.go`**
- `TestLifecycleEvents_Compression`: `EventCompressed` fires with `TokensBefore > TokensAfter` and correct `CompressionLevel`
- `TestLifecycleEvents_Eviction`: `EventEvicted` fires with `TokensAfter == 0`
- `TestRecall_CacheBoundaryHint`: near-exact embedding match produces a hint with ≥ 1 stable entry ID and positive confidence score

## Why

Without co-evolution, a document that is stable for 24 turns and then compressed from full text to summary causes a cache miss on the next request — the boundary still points to the full-text prefix, which no longer matches. `EventCompressed` lets the boundary manager retreat before that request is sent. Similarly, `EventEvicted` prevents the boundary from pointing to content that no longer exists.

The `CacheBoundaryHint` in `RecallResult` lets the boundary manager act on turn 1 for high-confidence recalled entries, rather than waiting `MinStableTurns` pushes to confirm stability independently.

## Dependency

Builds on the `CacheBoundaryManager` introduced in PR #56. The events and hint are emitted regardless of whether a boundary manager is registered — zero overhead when no handlers are attached.
