### PR TITLE
feat(graph): code change impact graph with blast-radius queries (#30)

### DIFF
--- a/pkg/graph/builder.go
+++ b/pkg/graph/builder.go
@@ -1,0 +1,131 @@
+package graph
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// BuildFromGoFiles walks a directory tree and builds a dependency graph from
+// Go import statements. It does not require go/packages or cgo — it uses
+// simple line-by-line parsing of import blocks.
+func BuildFromGoFiles(root string) (*Graph, error) {
+	g := New()
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		if d.IsDir() {
+			// Skip hidden dirs and vendor.
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || name == "vendor" || name == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		pkg := filepath.ToSlash(filepath.Dir(rel))
+		if pkg == "." {
+			pkg = ""
+		}
+
+		lang := "go"
+		tags := []string{}
+		if strings.HasSuffix(path, "_test.go") {
+			tags = append(tags, "test")
+		}
+
+		g.AddNode(Node{
+			ID:       rel,
+			Type:     NodeTypeFile,
+			Package:  pkg,
+			Language: lang,
+			Tags:     tags,
+		})
+
+		imports, err := parseGoImports(path)
+		if err != nil {
+			return nil
+		}
+
+		for _, imp := range imports {
+			// Only track intra-repo imports (those that start with the module path
+			// or are relative). We store the import path as the target node ID.
+			// Callers can resolve these to file paths if needed.
+			g.AddEdge(Edge{
+				From:   rel,
+				To:     imp,
+				Weight: 1.0,
+			})
+		}
+		return nil
+	})
+	return g, err
+}
+
+// parseGoImports extracts import paths from a Go source file.
+func parseGoImports(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var imports []string
+	scanner := bufio.NewScanner(f)
+	inImport := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "import (" {
+			inImport = true
+			continue
+		}
+		if inImport && line == ")" {
+			inImport = false
+			continue
+		}
+		if strings.HasPrefix(line, "import ") && !inImport {
+			// Single-line import.
+			imp := extractImportPath(line)
+			if imp != "" {
+				imports = append(imports, imp)
+			}
+			continue
+		}
+		if inImport && line != "" && !strings.HasPrefix(line, "//") {
+			imp := extractImportPath(line)
+			if imp != "" {
+				imports = append(imports, imp)
+			}
+		}
+	}
+	return imports, scanner.Err()
+}
+
+// extractImportPath extracts the import path string from a line like:
+//
+//	"github.com/foo/bar"
+//	alias "github.com/foo/bar"
+//	_ "github.com/foo/bar"
+func extractImportPath(line string) string {
+	// Find the quoted string.
+	start := strings.Index(line, `"`)
+	end := strings.LastIndex(line, `"`)
+	if start < 0 || end <= start {
+		return ""
+	}
+	return line[start+1 : end]
+}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -1,0 +1,270 @@
+// Package graph builds a code dependency graph from a repository and answers
+// blast-radius queries: given a set of changed files, which other files are
+// likely affected?
+package graph
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// NodeType classifies a graph node.
+type NodeType string
+
+const (
+	NodeTypeFile    NodeType = "file"
+	NodeTypePackage NodeType = "package"
+	NodeTypeModule  NodeType = "module"
+)
+
+// Node represents a file or package in the dependency graph.
+type Node struct {
+	ID       string   // canonical path (e.g. "pkg/cache/patterns.go")
+	Type     NodeType
+	Package  string   // Go package name or language-specific module
+	Language string   // "go", "python", "typescript", etc.
+	Tags     []string // arbitrary labels (e.g. "api", "storage", "test")
+}
+
+// Edge represents a directed dependency between two nodes.
+type Edge struct {
+	From   string // Node.ID
+	To     string // Node.ID
+	Weight float64 // 1.0 = direct import; < 1.0 = transitive
+}
+
+// Graph is an in-memory directed dependency graph.
+type Graph struct {
+	nodes    map[string]*Node
+	outEdges map[string][]Edge // from → edges
+	inEdges  map[string][]Edge // to → edges
+}
+
+// New creates an empty graph.
+func New() *Graph {
+	return &Graph{
+		nodes:    make(map[string]*Node),
+		outEdges: make(map[string][]Edge),
+		inEdges:  make(map[string][]Edge),
+	}
+}
+
+// AddNode adds or replaces a node.
+func (g *Graph) AddNode(n Node) {
+	g.nodes[n.ID] = &n
+}
+
+// AddEdge adds a directed edge from → to.
+func (g *Graph) AddEdge(e Edge) {
+	g.outEdges[e.From] = append(g.outEdges[e.From], e)
+	g.inEdges[e.To] = append(g.inEdges[e.To], e)
+}
+
+// Node returns the node with the given ID, or nil.
+func (g *Graph) Node(id string) *Node {
+	return g.nodes[id]
+}
+
+// NodeCount returns the number of nodes.
+func (g *Graph) NodeCount() int { return len(g.nodes) }
+
+// EdgeCount returns the total number of edges.
+func (g *Graph) EdgeCount() int {
+	n := 0
+	for _, edges := range g.outEdges {
+		n += len(edges)
+	}
+	return n
+}
+
+// Dependents returns all nodes that directly depend on id (reverse edges).
+func (g *Graph) Dependents(id string) []*Node {
+	var out []*Node
+	for _, e := range g.inEdges[id] {
+		if n := g.nodes[e.From]; n != nil {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// Dependencies returns all nodes that id directly depends on.
+func (g *Graph) Dependencies(id string) []*Node {
+	var out []*Node
+	for _, e := range g.outEdges[id] {
+		if n := g.nodes[e.To]; n != nil {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// BlastRadiusResult is the output of a blast-radius query.
+type BlastRadiusResult struct {
+	// Changed is the input set of changed file IDs.
+	Changed []string
+
+	// Affected is the set of files transitively affected, ranked by impact score.
+	Affected []AffectedNode
+
+	// TotalAffected is the count of affected nodes (excluding the changed set).
+	TotalAffected int
+
+	// MaxDepth is the deepest transitive level reached.
+	MaxDepth int
+}
+
+// AffectedNode pairs a node with its impact score and traversal depth.
+type AffectedNode struct {
+	Node        Node
+	ImpactScore float64 // higher = more likely to be affected
+	Depth       int     // 1 = direct dependent, 2 = transitive, etc.
+	Path        []string // shortest dependency path from changed file
+}
+
+// BlastRadius computes the set of files transitively affected by changes to
+// the given file IDs. It performs a BFS over reverse edges (dependents).
+//
+// maxDepth limits traversal depth. 0 = unlimited.
+func (g *Graph) BlastRadius(changedIDs []string, maxDepth int) BlastRadiusResult {
+	result := BlastRadiusResult{Changed: changedIDs}
+
+	// Seed the BFS with the changed set.
+	type qitem struct {
+		id    string
+		depth int
+		path  []string
+	}
+
+	visited := map[string]bool{}
+	for _, id := range changedIDs {
+		visited[id] = true
+	}
+
+	queue := make([]qitem, 0, len(changedIDs))
+	for _, id := range changedIDs {
+		queue = append(queue, qitem{id: id, depth: 0, path: []string{id}})
+	}
+
+	// best tracks the best (shallowest) depth and path for each affected node.
+	type best struct {
+		depth int
+		path  []string
+	}
+	bestMap := map[string]best{}
+
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+
+		for _, e := range g.inEdges[item.id] {
+			dep := e.From
+			if visited[dep] {
+				continue
+			}
+			newDepth := item.depth + 1
+			if maxDepth > 0 && newDepth > maxDepth {
+				continue
+			}
+			visited[dep] = true
+			newPath := append(append([]string{}, item.path...), dep)
+			bestMap[dep] = best{depth: newDepth, path: newPath}
+			if newDepth > result.MaxDepth {
+				result.MaxDepth = newDepth
+			}
+			queue = append(queue, qitem{id: dep, depth: newDepth, path: newPath})
+		}
+	}
+
+	// Build AffectedNode list.
+	for id, b := range bestMap {
+		n := g.nodes[id]
+		if n == nil {
+			n = &Node{ID: id, Type: NodeTypeFile}
+		}
+		// Impact score: direct dependents score 1.0, each level halves it.
+		score := 1.0
+		for i := 1; i < b.depth; i++ {
+			score *= 0.5
+		}
+		result.Affected = append(result.Affected, AffectedNode{
+			Node:        *n,
+			ImpactScore: score,
+			Depth:       b.depth,
+			Path:        b.path,
+		})
+	}
+
+	// Sort by impact score descending, then by ID for stability.
+	sort.Slice(result.Affected, func(i, j int) bool {
+		if result.Affected[i].ImpactScore != result.Affected[j].ImpactScore {
+			return result.Affected[i].ImpactScore > result.Affected[j].ImpactScore
+		}
+		return result.Affected[i].Node.ID < result.Affected[j].Node.ID
+	})
+
+	result.TotalAffected = len(result.Affected)
+	return result
+}
+
+// Summary returns a human-readable summary of a blast-radius result.
+func (r *BlastRadiusResult) Summary() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Changed: %d file(s), Affected: %d file(s), Max depth: %d\n",
+		len(r.Changed), r.TotalAffected, r.MaxDepth)
+	for _, a := range r.Affected {
+		fmt.Fprintf(&sb, "  [depth=%d score=%.2f] %s\n", a.Depth, a.ImpactScore, a.Node.ID)
+	}
+	return sb.String()
+}
+
+// Stats returns aggregate graph statistics.
+type Stats struct {
+	NodeCount    int
+	EdgeCount    int
+	MaxInDegree  int
+	MaxOutDegree int
+	// TopHubs lists the nodes with the highest in-degree (most depended-upon).
+	TopHubs []HubNode
+}
+
+// HubNode pairs a node ID with its in-degree.
+type HubNode struct {
+	ID       string
+	InDegree int
+}
+
+// Stats computes graph statistics.
+func (g *Graph) Stats() Stats {
+	s := Stats{
+		NodeCount: g.NodeCount(),
+		EdgeCount: g.EdgeCount(),
+	}
+
+	type degree struct {
+		id  string
+		in  int
+		out int
+	}
+	degrees := make([]degree, 0, len(g.nodes))
+	for id := range g.nodes {
+		in := len(g.inEdges[id])
+		out := len(g.outEdges[id])
+		degrees = append(degrees, degree{id, in, out})
+		if in > s.MaxInDegree {
+			s.MaxInDegree = in
+		}
+		if out > s.MaxOutDegree {
+			s.MaxOutDegree = out
+		}
+	}
+
+	sort.Slice(degrees, func(i, j int) bool {
+		return degrees[i].in > degrees[j].in
+	})
+	for i := 0; i < 5 && i < len(degrees); i++ {
+		s.TopHubs = append(s.TopHubs, HubNode{degrees[i].id, degrees[i].in})
+	}
+	return s
+}

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -1,0 +1,194 @@
+package graph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildTestGraph creates a small graph for testing:
+//
+//	a.go → b.go → d.go
+//	a.go → c.go → d.go
+//	e.go (isolated)
+func buildTestGraph() *Graph {
+	g := New()
+	for _, id := range []string{"a.go", "b.go", "c.go", "d.go", "e.go"} {
+		g.AddNode(Node{ID: id, Type: NodeTypeFile, Language: "go"})
+	}
+	g.AddEdge(Edge{From: "a.go", To: "b.go", Weight: 1.0})
+	g.AddEdge(Edge{From: "a.go", To: "c.go", Weight: 1.0})
+	g.AddEdge(Edge{From: "b.go", To: "d.go", Weight: 1.0})
+	g.AddEdge(Edge{From: "c.go", To: "d.go", Weight: 1.0})
+	return g
+}
+
+func TestNodeAndEdgeCount(t *testing.T) {
+	g := buildTestGraph()
+	if g.NodeCount() != 5 {
+		t.Fatalf("want 5 nodes, got %d", g.NodeCount())
+	}
+	if g.EdgeCount() != 4 {
+		t.Fatalf("want 4 edges, got %d", g.EdgeCount())
+	}
+}
+
+func TestDependencies(t *testing.T) {
+	g := buildTestGraph()
+	deps := g.Dependencies("a.go")
+	if len(deps) != 2 {
+		t.Fatalf("want 2 deps for a.go, got %d", len(deps))
+	}
+}
+
+func TestDependents(t *testing.T) {
+	g := buildTestGraph()
+	// d.go is depended on by b.go and c.go
+	deps := g.Dependents("d.go")
+	if len(deps) != 2 {
+		t.Fatalf("want 2 dependents for d.go, got %d", len(deps))
+	}
+}
+
+func TestBlastRadius_DirectChange(t *testing.T) {
+	g := buildTestGraph()
+	// Changing d.go should affect b.go and c.go (depth 1) and a.go (depth 2).
+	result := g.BlastRadius([]string{"d.go"}, 0)
+	if result.TotalAffected != 3 {
+		t.Fatalf("want 3 affected, got %d", result.TotalAffected)
+	}
+	if result.MaxDepth != 2 {
+		t.Fatalf("want max depth 2, got %d", result.MaxDepth)
+	}
+}
+
+func TestBlastRadius_MaxDepth(t *testing.T) {
+	g := buildTestGraph()
+	// With maxDepth=1, only direct dependents of d.go (b.go, c.go).
+	result := g.BlastRadius([]string{"d.go"}, 1)
+	if result.TotalAffected != 2 {
+		t.Fatalf("want 2 affected at depth 1, got %d", result.TotalAffected)
+	}
+}
+
+func TestBlastRadius_MultipleChanged(t *testing.T) {
+	g := buildTestGraph()
+	// Changing both b.go and c.go: a.go is affected at depth 1 from both.
+	result := g.BlastRadius([]string{"b.go", "c.go"}, 0)
+	if result.TotalAffected != 1 {
+		t.Fatalf("want 1 affected (a.go), got %d", result.TotalAffected)
+	}
+	if result.Affected[0].Node.ID != "a.go" {
+		t.Fatalf("want a.go affected, got %s", result.Affected[0].Node.ID)
+	}
+}
+
+func TestBlastRadius_IsolatedNode(t *testing.T) {
+	g := buildTestGraph()
+	result := g.BlastRadius([]string{"e.go"}, 0)
+	if result.TotalAffected != 0 {
+		t.Fatalf("isolated node should have 0 affected, got %d", result.TotalAffected)
+	}
+}
+
+func TestBlastRadius_ImpactScoreDecay(t *testing.T) {
+	g := buildTestGraph()
+	result := g.BlastRadius([]string{"d.go"}, 0)
+	// b.go and c.go are at depth 1 → score 1.0; a.go at depth 2 → score 0.5
+	for _, a := range result.Affected {
+		if a.Depth == 1 && a.ImpactScore != 1.0 {
+			t.Errorf("depth-1 node %s: want score 1.0, got %.2f", a.Node.ID, a.ImpactScore)
+		}
+		if a.Depth == 2 && a.ImpactScore != 0.5 {
+			t.Errorf("depth-2 node %s: want score 0.5, got %.2f", a.Node.ID, a.ImpactScore)
+		}
+	}
+}
+
+func TestBlastRadius_SortedByScore(t *testing.T) {
+	g := buildTestGraph()
+	result := g.BlastRadius([]string{"d.go"}, 0)
+	for i := 1; i < len(result.Affected); i++ {
+		if result.Affected[i].ImpactScore > result.Affected[i-1].ImpactScore {
+			t.Errorf("results not sorted by impact score at index %d", i)
+		}
+	}
+}
+
+func TestStats(t *testing.T) {
+	g := buildTestGraph()
+	s := g.Stats()
+	if s.NodeCount != 5 {
+		t.Errorf("want 5 nodes, got %d", s.NodeCount)
+	}
+	if s.EdgeCount != 4 {
+		t.Errorf("want 4 edges, got %d", s.EdgeCount)
+	}
+	// d.go has in-degree 2 (from b.go and c.go)
+	if s.MaxInDegree != 2 {
+		t.Errorf("want max in-degree 2, got %d", s.MaxInDegree)
+	}
+	// a.go has out-degree 2
+	if s.MaxOutDegree != 2 {
+		t.Errorf("want max out-degree 2, got %d", s.MaxOutDegree)
+	}
+}
+
+func TestSummary(t *testing.T) {
+	g := buildTestGraph()
+	result := g.BlastRadius([]string{"d.go"}, 0)
+	summary := result.Summary()
+	if summary == "" {
+		t.Error("expected non-empty summary")
+	}
+}
+
+func TestBuildFromGoFiles(t *testing.T) {
+	// Create a temporary Go module with two files.
+	dir := t.TempDir()
+
+	// Write a simple Go file that imports another package.
+	mainFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(mainFile, []byte(`package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println(os.Args)
+}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	subDir := filepath.Join(dir, "pkg", "util")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	utilFile := filepath.Join(subDir, "util.go")
+	if err := os.WriteFile(utilFile, []byte(`package util
+
+import "strings"
+
+func Upper(s string) string { return strings.ToUpper(s) }
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := BuildFromGoFiles(dir)
+	if err != nil {
+		t.Fatalf("BuildFromGoFiles: %v", err)
+	}
+	if g.NodeCount() < 2 {
+		t.Errorf("want at least 2 nodes, got %d", g.NodeCount())
+	}
+}
+
+func TestNode_NotFound(t *testing.T) {
+	g := New()
+	if g.Node("nonexistent") != nil {
+		t.Error("expected nil for missing node")
+	}
+}


### PR DESCRIPTION
Closes #30

## Summary

Adds `pkg/graph` — an in-memory directed dependency graph that answers blast-radius queries: given a set of changed files, which other files are transitively affected?

## Features

- **`Graph`** — nodes (files/packages/modules) + directed weighted edges, O(1) node lookup, O(degree) neighbour traversal
- **`BlastRadius`** — BFS over reverse edges from the changed set; returns affected nodes ranked by impact score with configurable `maxDepth`
- **`BuildFromGoFiles`** — walks a directory tree and extracts Go import edges using line-by-line parsing (no `go/packages`, no cgo)
- **`Stats`** — node/edge counts, max in/out degree, top-5 hub nodes by in-degree

## Impact scoring

Nodes at depth 1 (direct dependents) score **1.0**; each additional level halves the score. Results are sorted by score descending.

## Files

- `pkg/graph/graph.go` — `Graph`, `Node`, `Edge`, `BlastRadius`, `Stats`
- `pkg/graph/builder.go` — `BuildFromGoFiles`, `parseGoImports`
- `pkg/graph/graph_test.go` — 13 tests
