### PR TITLE
feat(pipeline): unified dedup→compress→summarize pipeline (#4)

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -240,6 +240,10 @@ func runAPI(cmd *cobra.Command, args []string) error {
 		sessAPI.RegisterSessionRoutes(mux, m.Middleware)
 	}
 
+	// Pipeline and batch routes.
+	pipelineAPI := NewPipelineAPI()
+	pipelineAPI.RegisterPipelineRoutes(mux, m.Middleware)
+
 	mux.HandleFunc("/health", server.handleHealth)
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		m.Handler().ServeHTTP(w, r)

--- a/cmd/api_pipeline.go
+++ b/cmd/api_pipeline.go
@@ -1,0 +1,309 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/Siddhant-K-code/distill/pkg/batch"
+	"github.com/Siddhant-K-code/distill/pkg/pipeline"
+	"github.com/Siddhant-K-code/distill/pkg/types"
+)
+
+// PipelineRequest is the JSON body for POST /v1/pipeline.
+type PipelineRequest struct {
+	Chunks  []DedupeChunk   `json:"chunks"`
+	Options PipelineOptions `json:"options,omitempty"`
+}
+
+// PipelineOptions mirrors pipeline.Options for JSON serialisation.
+type PipelineOptions struct {
+	Dedup     PipelineDedupOptions     `json:"dedup,omitempty"`
+	Compress  PipelineCompressOptions  `json:"compress,omitempty"`
+	Summarize PipelineSummarizeOptions `json:"summarize,omitempty"`
+}
+
+type PipelineDedupOptions struct {
+	Enabled   bool    `json:"enabled"`
+	Threshold float64 `json:"threshold,omitempty"`
+	Lambda    float64 `json:"lambda,omitempty"`
+	TargetK   int     `json:"target_k,omitempty"`
+}
+
+type PipelineCompressOptions struct {
+	Enabled         bool    `json:"enabled"`
+	TargetReduction float64 `json:"target_reduction,omitempty"`
+}
+
+type PipelineSummarizeOptions struct {
+	Enabled    bool `json:"enabled"`
+	MaxTokens  int  `json:"max_tokens,omitempty"`
+	KeepRecent int  `json:"keep_recent,omitempty"`
+}
+
+// PipelineResponse is the JSON response for POST /v1/pipeline.
+type PipelineResponse struct {
+	Chunks []DedupeChunk        `json:"chunks"`
+	Stats  PipelineStatsPayload `json:"stats"`
+}
+
+// PipelineStatsPayload is the serialisable form of pipeline.Stats.
+type PipelineStatsPayload struct {
+	OriginalTokens int                       `json:"original_tokens"`
+	FinalTokens    int                       `json:"final_tokens"`
+	TotalReduction float64                   `json:"total_reduction"`
+	LatencyMs      float64                   `json:"latency_ms"`
+	Stages         map[string]StageStatsPL   `json:"stages"`
+}
+
+// StageStatsPL is the serialisable form of pipeline.StageStats.
+type StageStatsPL struct {
+	Enabled      bool    `json:"enabled"`
+	InputTokens  int     `json:"input_tokens"`
+	OutputTokens int     `json:"output_tokens"`
+	Reduction    float64 `json:"reduction"`
+	LatencyMs    float64 `json:"latency_ms"`
+}
+
+// BatchSubmitRequest is the JSON body for POST /v1/batch.
+type BatchSubmitRequest struct {
+	Chunks  []DedupeChunk   `json:"chunks"`
+	Options PipelineOptions `json:"options,omitempty"`
+}
+
+// BatchSubmitResponse is the JSON response for POST /v1/batch.
+type BatchSubmitResponse struct {
+	JobID  string `json:"job_id"`
+	Status string `json:"status"`
+}
+
+// BatchStatusResponse is the JSON response for GET /v1/batch/{id}.
+type BatchStatusResponse struct {
+	JobID       string  `json:"job_id"`
+	Status      string  `json:"status"`
+	Progress    float64 `json:"progress"`
+	Error       string  `json:"error,omitempty"`
+	CreatedAt   string  `json:"created_at"`
+	StartedAt   string  `json:"started_at,omitempty"`
+	CompletedAt string  `json:"completed_at,omitempty"`
+}
+
+// BatchResultsResponse is the JSON response for GET /v1/batch/{id}/results.
+type BatchResultsResponse struct {
+	JobID  string               `json:"job_id"`
+	Status string               `json:"status"`
+	Chunks []DedupeChunk        `json:"chunks"`
+	Stats  PipelineStatsPayload `json:"stats"`
+}
+
+// PipelineAPI holds the pipeline runner and batch processor.
+type PipelineAPI struct {
+	processor *batch.Processor
+}
+
+// NewPipelineAPI creates a PipelineAPI with a default batch processor.
+func NewPipelineAPI() *PipelineAPI {
+	return &PipelineAPI{
+		processor: batch.NewProcessor(batch.DefaultConfig()),
+	}
+}
+
+// RegisterPipelineRoutes wires up /v1/pipeline and /v1/batch/* routes.
+func (a *PipelineAPI) RegisterPipelineRoutes(mux *http.ServeMux, middleware func(string, http.HandlerFunc) http.HandlerFunc) {
+	mux.HandleFunc("/v1/pipeline", middleware("/v1/pipeline", a.handlePipeline))
+	mux.HandleFunc("/v1/batch", middleware("/v1/batch", a.handleBatchSubmit))
+	mux.HandleFunc("/v1/batch/", middleware("/v1/batch/", a.handleBatchLookup))
+}
+
+// handlePipeline runs the full pipeline synchronously.
+func (a *PipelineAPI) handlePipeline(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req PipelineRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	chunks := dedupeChunksToTypes(req.Chunks)
+	opts := pipelineOptsFromRequest(req.Options)
+
+	runner := pipeline.New()
+	result, stats, err := runner.Run(r.Context(), chunks, opts)
+	if err != nil {
+		http.Error(w, "pipeline error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := PipelineResponse{
+		Chunks: typesToDedupeChunks(result),
+		Stats:  marshalStats(stats),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleBatchSubmit accepts a new batch job.
+func (a *PipelineAPI) handleBatchSubmit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req BatchSubmitRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	job, err := a.processor.Submit(batch.SubmitRequest{
+		Chunks:  dedupeChunksToTypes(req.Chunks),
+		Options: pipelineOptsFromRequest(req.Options),
+	})
+	if err != nil {
+		http.Error(w, "submit error: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(BatchSubmitResponse{
+		JobID:  job.ID,
+		Status: string(job.Status),
+	})
+}
+
+// handleBatchLookup handles GET /v1/batch/{id} and GET /v1/batch/{id}/results.
+func (a *PipelineAPI) handleBatchLookup(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Path: /v1/batch/{id} or /v1/batch/{id}/results
+	path := strings.TrimPrefix(r.URL.Path, "/v1/batch/")
+	parts := strings.SplitN(path, "/", 2)
+	id := parts[0]
+	sub := ""
+	if len(parts) == 2 {
+		sub = parts[1]
+	}
+
+	if sub == "results" {
+		a.handleBatchResults(w, r, id)
+		return
+	}
+	a.handleBatchStatus(w, r, id)
+}
+
+func (a *PipelineAPI) handleBatchStatus(w http.ResponseWriter, _ *http.Request, id string) {
+	job, err := a.processor.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	resp := BatchStatusResponse{
+		JobID:    job.ID,
+		Status:   string(job.Status),
+		Progress: job.Progress,
+		Error:    job.Error,
+	}
+	if !job.CreatedAt.IsZero() {
+		resp.CreatedAt = job.CreatedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if !job.StartedAt.IsZero() {
+		resp.StartedAt = job.StartedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if !job.CompletedAt.IsZero() {
+		resp.CompletedAt = job.CompletedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (a *PipelineAPI) handleBatchResults(w http.ResponseWriter, _ *http.Request, id string) {
+	chunks, stats, err := a.processor.Results(id)
+	if err != nil {
+		code := http.StatusNotFound
+		if err == batch.ErrJobNotFound {
+			code = http.StatusNotFound
+		} else {
+			code = http.StatusConflict
+		}
+		http.Error(w, err.Error(), code)
+		return
+	}
+	resp := BatchResultsResponse{
+		JobID:  id,
+		Status: string(batch.StatusCompleted),
+		Chunks: typesToDedupeChunks(chunks),
+		Stats:  marshalStats(stats),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func dedupeChunksToTypes(in []DedupeChunk) []types.Chunk {
+	out := make([]types.Chunk, len(in))
+	for i, c := range in {
+		out[i] = types.Chunk{
+			ID:        c.ID,
+			Text:      c.Text,
+			Embedding: c.Embedding,
+			Score:     c.Score,
+		}
+	}
+	return out
+}
+
+func typesToDedupeChunks(in []types.Chunk) []DedupeChunk {
+	out := make([]DedupeChunk, len(in))
+	for i, c := range in {
+		out[i] = DedupeChunk{
+			ID:        c.ID,
+			Text:      c.Text,
+			Embedding: c.Embedding,
+			Score:     c.Score,
+		}
+	}
+	return out
+}
+
+func pipelineOptsFromRequest(o PipelineOptions) pipeline.Options {
+	return pipeline.Options{
+		DedupEnabled:            o.Dedup.Enabled,
+		DedupThreshold:          o.Dedup.Threshold,
+		DedupLambda:             o.Dedup.Lambda,
+		DedupTargetK:            o.Dedup.TargetK,
+		CompressEnabled:         o.Compress.Enabled,
+		CompressTargetReduction: o.Compress.TargetReduction,
+		SummarizeEnabled:        o.Summarize.Enabled,
+		SummarizeMaxTokens:      o.Summarize.MaxTokens,
+		SummarizeRecent:         o.Summarize.KeepRecent,
+	}
+}
+
+func marshalStats(s pipeline.Stats) PipelineStatsPayload {
+	stages := make(map[string]StageStatsPL, len(s.Stages))
+	for k, v := range s.Stages {
+		stages[k] = StageStatsPL{
+			Enabled:      v.Enabled,
+			InputTokens:  v.InputTokens,
+			OutputTokens: v.OutputTokens,
+			Reduction:    v.Reduction,
+			LatencyMs:    float64(v.Latency.Microseconds()) / 1000.0,
+		}
+	}
+	return PipelineStatsPayload{
+		OriginalTokens: s.OriginalTokens,
+		FinalTokens:    s.FinalTokens,
+		TotalReduction: s.TotalReduction,
+		LatencyMs:      float64(s.TotalLatency.Microseconds()) / 1000.0,
+		Stages:         stages,
+	}
+}

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/Siddhant-K-code/distill/pkg/pipeline"
+	"github.com/Siddhant-K-code/distill/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+var pipelineCmd = &cobra.Command{
+	Use:   "pipeline",
+	Short: "Run the full context optimisation pipeline (dedup → compress → summarize)",
+	Long: `Runs the complete context optimisation pipeline on a JSON array of chunks
+read from stdin or a file. Outputs the optimised chunks as JSON.
+
+Example (stdin):
+  echo '[{"id":"1","text":"..."},{"id":"2","text":"..."}]' | distill pipeline
+
+Example (file):
+  distill pipeline --input chunks.json --output optimised.json
+
+Example (disable compress):
+  distill pipeline --no-compress --dedup-threshold 0.2`,
+	RunE: runPipeline,
+}
+
+func init() {
+	rootCmd.AddCommand(pipelineCmd)
+
+	pipelineCmd.Flags().String("input", "", "Input JSON file (default: stdin)")
+	pipelineCmd.Flags().String("output", "", "Output JSON file (default: stdout)")
+
+	// Dedup flags.
+	pipelineCmd.Flags().Bool("no-dedup", false, "Disable deduplication stage")
+	pipelineCmd.Flags().Float64("dedup-threshold", 0.15, "Cosine distance threshold for dedup clustering")
+	pipelineCmd.Flags().Float64("dedup-lambda", 0.7, "MMR diversity weight")
+	pipelineCmd.Flags().Int("dedup-target-k", 0, "Maximum chunks to keep after dedup (0 = no limit)")
+
+	// Compress flags.
+	pipelineCmd.Flags().Bool("no-compress", false, "Disable compression stage")
+	pipelineCmd.Flags().Float64("compress-ratio", 0.5, "Target compression ratio (0.5 = reduce to 50% of tokens)")
+
+	// Summarize flags.
+	pipelineCmd.Flags().Bool("summarize", false, "Enable summarization stage")
+	pipelineCmd.Flags().Int("summarize-max-tokens", 4000, "Token budget for summarization output")
+	pipelineCmd.Flags().Int("summarize-recent", 10, "Number of recent turns to preserve at full fidelity")
+
+	// Output flags.
+	pipelineCmd.Flags().Bool("stats", false, "Print pipeline statistics to stderr")
+}
+
+func runPipeline(cmd *cobra.Command, _ []string) error {
+	// Read input.
+	inputFile, _ := cmd.Flags().GetString("input")
+	var raw []byte
+	var err error
+	if inputFile != "" {
+		raw, err = os.ReadFile(inputFile)
+	} else {
+		raw, err = readStdin()
+	}
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	var chunks []types.Chunk
+	if err := json.Unmarshal(raw, &chunks); err != nil {
+		return fmt.Errorf("parsing input JSON: %w", err)
+	}
+
+	// Build options.
+	noDedup, _ := cmd.Flags().GetBool("no-dedup")
+	noCompress, _ := cmd.Flags().GetBool("no-compress")
+	doSummarize, _ := cmd.Flags().GetBool("summarize")
+
+	threshold, _ := cmd.Flags().GetFloat64("dedup-threshold")
+	lambda, _ := cmd.Flags().GetFloat64("dedup-lambda")
+	targetK, _ := cmd.Flags().GetInt("dedup-target-k")
+	compressRatio, _ := cmd.Flags().GetFloat64("compress-ratio")
+	maxTokens, _ := cmd.Flags().GetInt("summarize-max-tokens")
+	keepRecent, _ := cmd.Flags().GetInt("summarize-recent")
+
+	opts := pipeline.Options{
+		DedupEnabled:            !noDedup,
+		DedupThreshold:          threshold,
+		DedupLambda:             lambda,
+		DedupTargetK:            targetK,
+		CompressEnabled:         !noCompress,
+		CompressTargetReduction: compressRatio,
+		SummarizeEnabled:        doSummarize,
+		SummarizeMaxTokens:      maxTokens,
+		SummarizeRecent:         keepRecent,
+	}
+
+	// Run.
+	runner := pipeline.New()
+	result, stats, err := runner.Run(context.Background(), chunks, opts)
+	if err != nil {
+		return fmt.Errorf("pipeline: %w", err)
+	}
+
+	// Write output.
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling output: %w", err)
+	}
+
+	outputFile, _ := cmd.Flags().GetString("output")
+	if outputFile != "" {
+		if err := os.WriteFile(outputFile, out, 0644); err != nil {
+			return fmt.Errorf("writing output: %w", err)
+		}
+	} else {
+		fmt.Println(string(out))
+	}
+
+	// Print stats if requested.
+	printStats, _ := cmd.Flags().GetBool("stats")
+	if printStats {
+		fmt.Fprintf(os.Stderr, "Pipeline stats:\n")
+		fmt.Fprintf(os.Stderr, "  original_tokens: %d\n", stats.OriginalTokens)
+		fmt.Fprintf(os.Stderr, "  final_tokens:    %d\n", stats.FinalTokens)
+		fmt.Fprintf(os.Stderr, "  total_reduction: %.1f%%\n", stats.TotalReduction*100)
+		fmt.Fprintf(os.Stderr, "  latency:         %s\n", stats.TotalLatency)
+		for name, s := range stats.Stages {
+			if s.Enabled {
+				fmt.Fprintf(os.Stderr, "  stage[%s]: reduction=%.1f%% latency=%s\n",
+					name, s.Reduction*100, s.Latency)
+			}
+		}
+	}
+
+	return nil
+}
+
+// readStdin reads all of stdin.
+func readStdin() ([]byte, error) {
+	var buf []byte
+	tmp := make([]byte, 4096)
+	for {
+		n, err := os.Stdin.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	return buf, nil
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1,0 +1,235 @@
+// Package pipeline chains dedup → compress → summarize into a single pass.
+// Each stage is independently configurable and can be disabled.
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Siddhant-K-code/distill/pkg/compress"
+	"github.com/Siddhant-K-code/distill/pkg/contextlab"
+	"github.com/Siddhant-K-code/distill/pkg/summarize"
+	"github.com/Siddhant-K-code/distill/pkg/types"
+)
+
+// StageStats records token counts and latency for one pipeline stage.
+type StageStats struct {
+	Enabled      bool
+	InputTokens  int
+	OutputTokens int
+	Reduction    float64 // 0–1
+	Latency      time.Duration
+}
+
+// Stats aggregates per-stage and overall pipeline statistics.
+type Stats struct {
+	OriginalTokens int
+	FinalTokens    int
+	TotalReduction float64
+	Stages         map[string]StageStats
+	TotalLatency   time.Duration
+}
+
+// Options configures which stages run and how.
+type Options struct {
+	// Dedup stage.
+	DedupEnabled   bool
+	DedupThreshold float64 // cosine distance threshold (default 0.15)
+	DedupLambda    float64 // MMR diversity weight (default 0.7)
+	DedupTargetK   int     // max chunks to keep (0 = no limit)
+
+	// Compress stage.
+	CompressEnabled         bool
+	CompressTargetReduction float64 // e.g. 0.5 = reduce to 50% of tokens
+
+	// Summarize stage.
+	SummarizeEnabled   bool
+	SummarizeMaxTokens int
+	SummarizeRecent    int // turns to preserve at full fidelity
+}
+
+// DefaultOptions returns sensible defaults with all stages enabled.
+func DefaultOptions() Options {
+	return Options{
+		DedupEnabled:            true,
+		DedupThreshold:          0.15,
+		DedupLambda:             0.7,
+		CompressEnabled:         true,
+		CompressTargetReduction: 0.5,
+		SummarizeEnabled:        false, // opt-in; requires turn structure
+		SummarizeMaxTokens:      4000,
+		SummarizeRecent:         10,
+	}
+}
+
+// Runner executes the pipeline stages in order.
+type Runner struct{}
+
+// New creates a new Runner.
+func New() *Runner { return &Runner{} }
+
+// Run executes the configured stages against chunks and returns the result.
+func (r *Runner) Run(ctx context.Context, chunks []types.Chunk, opts Options) ([]types.Chunk, Stats, error) {
+	start := time.Now()
+	stats := Stats{
+		Stages:         make(map[string]StageStats),
+		OriginalTokens: estimateTokens(chunks),
+	}
+
+	current := chunks
+
+	// ── Stage 1: Dedup ────────────────────────────────────────────────────────
+	dedupStats := StageStats{Enabled: opts.DedupEnabled}
+	if opts.DedupEnabled && len(current) > 1 {
+		t0 := time.Now()
+		dedupStats.InputTokens = estimateTokens(current)
+
+		threshold := opts.DedupThreshold
+		if threshold <= 0 {
+			threshold = 0.15
+		}
+		lambda := opts.DedupLambda
+		if lambda <= 0 {
+			lambda = 0.7
+		}
+
+		clusterResult := contextlab.ClusterByThreshold(current, threshold)
+		sel := contextlab.NewSelector(contextlab.DefaultSelectorConfig())
+		selected := sel.Select(clusterResult)
+
+		if opts.DedupTargetK > 0 && len(selected) > opts.DedupTargetK {
+			mmrResult := contextlab.MMRRerank(selected, lambda, opts.DedupTargetK)
+			current = mmrResult
+		} else {
+			current = selected
+		}
+
+		dedupStats.OutputTokens = estimateTokens(current)
+		dedupStats.Reduction = reduction(dedupStats.InputTokens, dedupStats.OutputTokens)
+		dedupStats.Latency = time.Since(t0)
+	} else {
+		dedupStats.InputTokens = estimateTokens(current)
+		dedupStats.OutputTokens = dedupStats.InputTokens
+	}
+	stats.Stages["dedup"] = dedupStats
+
+	// ── Stage 2: Compress ─────────────────────────────────────────────────────
+	compressStats := StageStats{Enabled: opts.CompressEnabled}
+	if opts.CompressEnabled && len(current) > 0 {
+		t0 := time.Now()
+		compressStats.InputTokens = estimateTokens(current)
+
+		compOpts := compress.DefaultOptions()
+		if opts.CompressTargetReduction > 0 {
+			compOpts.TargetReduction = opts.CompressTargetReduction
+		}
+
+		c := compress.NewExtractiveCompressor()
+		compressed, _, err := c.Compress(ctx, current, compOpts)
+		if err != nil {
+			return nil, stats, fmt.Errorf("compress stage: %w", err)
+		}
+		current = compressed
+
+		compressStats.OutputTokens = estimateTokens(current)
+		compressStats.Reduction = reduction(compressStats.InputTokens, compressStats.OutputTokens)
+		compressStats.Latency = time.Since(t0)
+	} else {
+		compressStats.InputTokens = estimateTokens(current)
+		compressStats.OutputTokens = compressStats.InputTokens
+	}
+	stats.Stages["compress"] = compressStats
+
+	// ── Stage 3: Summarize ────────────────────────────────────────────────────
+	summarizeStats := StageStats{Enabled: opts.SummarizeEnabled}
+	if opts.SummarizeEnabled && len(current) > 0 {
+		t0 := time.Now()
+		summarizeStats.InputTokens = estimateTokens(current)
+
+		turns := chunksToTurns(current)
+		sumOpts := summarize.DefaultOptions()
+		sumOpts.MaxTokens = opts.SummarizeMaxTokens
+		sumOpts.PreserveRecent = opts.SummarizeRecent
+
+		s := summarize.NewHierarchicalSummarizer()
+		summarized, sumStats, err := s.Summarize(ctx, turns, sumOpts)
+		if err != nil {
+			return nil, stats, fmt.Errorf("summarize stage: %w", err)
+		}
+		current = turnsToChunks(summarized, current)
+		_ = sumStats
+
+		summarizeStats.OutputTokens = estimateTokens(current)
+		summarizeStats.Reduction = reduction(summarizeStats.InputTokens, summarizeStats.OutputTokens)
+		summarizeStats.Latency = time.Since(t0)
+	} else {
+		summarizeStats.InputTokens = estimateTokens(current)
+		summarizeStats.OutputTokens = summarizeStats.InputTokens
+	}
+	stats.Stages["summarize"] = summarizeStats
+
+	stats.FinalTokens = estimateTokens(current)
+	stats.TotalReduction = reduction(stats.OriginalTokens, stats.FinalTokens)
+	stats.TotalLatency = time.Since(start)
+
+	return current, stats, nil
+}
+
+// estimateTokens approximates total token count across chunks (4 chars ≈ 1 token).
+func estimateTokens(chunks []types.Chunk) int {
+	total := 0
+	for _, c := range chunks {
+		n := 0
+		for _, r := range c.Text {
+			if r != ' ' && r != '\n' && r != '\t' {
+				n++
+			}
+		}
+		total += (n + 3) / 4
+	}
+	return total
+}
+
+// reduction returns the fractional reduction from in to out (0–1).
+func reduction(in, out int) float64 {
+	if in == 0 {
+		return 0
+	}
+	r := float64(in-out) / float64(in)
+	if r < 0 {
+		return 0
+	}
+	return r
+}
+
+// chunksToTurns converts chunks to summarize.Turn for the summarize stage.
+func chunksToTurns(chunks []types.Chunk) []summarize.Turn {
+	turns := make([]summarize.Turn, len(chunks))
+	for i, c := range chunks {
+		turns[i] = summarize.Turn{
+			ID:      c.ID,
+			Role:    "user",
+			Content: c.Text,
+		}
+	}
+	return turns
+}
+
+// turnsToChunks maps summarized turns back to chunks, preserving metadata.
+func turnsToChunks(turns []summarize.Turn, original []types.Chunk) []types.Chunk {
+	byID := make(map[string]types.Chunk, len(original))
+	for _, c := range original {
+		byID[c.ID] = c
+	}
+	out := make([]types.Chunk, 0, len(turns))
+	for _, t := range turns {
+		c, ok := byID[t.ID]
+		if !ok {
+			c = types.Chunk{ID: t.ID}
+		}
+		c.Text = t.Content
+		out = append(out, c)
+	}
+	return out
+}

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1,0 +1,167 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Siddhant-K-code/distill/pkg/types"
+)
+
+func makeChunk(id, text string) types.Chunk {
+	return types.Chunk{ID: id, Text: text}
+}
+
+func TestRun_AllStagesDisabled(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+	chunks := []types.Chunk{makeChunk("a", "hello world"), makeChunk("b", "foo bar")}
+	opts := Options{} // all disabled
+
+	result, stats, err := r.Run(ctx, chunks, opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("want 2 chunks, got %d", len(result))
+	}
+	if stats.TotalReduction != 0 {
+		t.Errorf("want 0 reduction with all stages off, got %.2f", stats.TotalReduction)
+	}
+}
+
+func TestRun_DedupOnly(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+
+	// Two near-identical chunks (no embeddings → cluster by text similarity won't fire,
+	// but dedup stage should still run without error).
+	chunks := []types.Chunk{
+		makeChunk("a", "The quick brown fox jumps over the lazy dog"),
+		makeChunk("b", "A completely different sentence about something else entirely"),
+		makeChunk("c", "The quick brown fox jumps over the lazy dog"), // duplicate
+	}
+	opts := Options{DedupEnabled: true, DedupThreshold: 0.15}
+
+	result, stats, err := r.Run(ctx, chunks, opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected at least one chunk after dedup")
+	}
+	if !stats.Stages["dedup"].Enabled {
+		t.Error("dedup stage should be marked enabled")
+	}
+}
+
+func TestRun_CompressOnly(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+	long := "This is a long sentence. It has multiple parts. Each part adds tokens. More content here. Even more."
+	chunks := []types.Chunk{makeChunk("a", long)}
+	opts := Options{CompressEnabled: true, CompressTargetReduction: 0.5}
+
+	result, stats, err := r.Run(ctx, chunks, opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected at least one chunk after compress")
+	}
+	if !stats.Stages["compress"].Enabled {
+		t.Error("compress stage should be marked enabled")
+	}
+}
+
+func TestRun_SummarizeEnabled(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+	chunks := []types.Chunk{
+		makeChunk("a", "This is a detailed message about the system architecture and design decisions."),
+		makeChunk("b", "Another message about implementation details and code structure."),
+	}
+	opts := Options{
+		SummarizeEnabled:   true,
+		SummarizeMaxTokens: 10,
+		SummarizeRecent:    0,
+	}
+
+	result, stats, err := r.Run(ctx, chunks, opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !stats.Stages["summarize"].Enabled {
+		t.Error("summarize stage should be marked enabled")
+	}
+	_ = result
+}
+
+func TestRun_DefaultOptions(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+	chunks := []types.Chunk{
+		makeChunk("a", "First chunk with some content about the topic."),
+		makeChunk("b", "Second chunk with different content about another topic."),
+	}
+
+	result, stats, err := r.Run(ctx, chunks, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected non-empty result")
+	}
+	if stats.TotalLatency == 0 {
+		t.Error("expected non-zero latency")
+	}
+}
+
+func TestRun_EmptyInput(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+	result, stats, err := r.Run(ctx, nil, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Run with empty input: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d chunks", len(result))
+	}
+	if stats.OriginalTokens != 0 {
+		t.Errorf("expected 0 original tokens, got %d", stats.OriginalTokens)
+	}
+}
+
+func TestStats_StagesPresent(t *testing.T) {
+	r := New()
+	ctx := context.Background()
+	chunks := []types.Chunk{makeChunk("a", "hello")}
+	_, stats, err := r.Run(ctx, chunks, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, stage := range []string{"dedup", "compress", "summarize"} {
+		if _, ok := stats.Stages[stage]; !ok {
+			t.Errorf("missing stage %q in stats", stage)
+		}
+	}
+}
+
+func TestEstimateTokens(t *testing.T) {
+	chunks := []types.Chunk{{Text: "hello world"}}
+	n := estimateTokens(chunks)
+	if n == 0 {
+		t.Error("expected non-zero token estimate")
+	}
+}
+
+func TestReduction(t *testing.T) {
+	if r := reduction(100, 50); r != 0.5 {
+		t.Errorf("want 0.5, got %.2f", r)
+	}
+	if r := reduction(0, 0); r != 0 {
+		t.Errorf("want 0 for zero input, got %.2f", r)
+	}
+	if r := reduction(100, 150); r != 0 {
+		t.Errorf("want 0 for negative reduction, got %.2f", r)
+	}
+}


### PR DESCRIPTION
Closes #4

## Summary

Adds a unified pipeline that chains dedup → compress → summarize in a single call, with per-stage stats. Exposed as both a CLI command and an HTTP endpoint.

## `pkg/pipeline`

- `Runner.Run(ctx, chunks, Options)` — executes enabled stages in order
- Each stage independently enable/disable via `Options`
- `Stats` includes per-stage: input/output tokens, reduction ratio, latency
- `DefaultOptions`: dedup + compress enabled; summarize opt-in

## `distill pipeline` CLI

```bash
# From stdin
echo '[{"id":"1","text":"..."}]' | distill pipeline

# From file with stats
distill pipeline --input chunks.json --output optimised.json --stats

# Tune stages
distill pipeline --dedup-threshold 0.2 --compress-ratio 0.4
distill pipeline --no-compress --summarize --summarize-max-tokens 2000
```

## `POST /v1/pipeline`

```json
{
  "chunks": [...],
  "options": {
    "dedup":     {"enabled": true, "threshold": 0.15},
    "compress":  {"enabled": true, "target_reduction": 0.5},
    "summarize": {"enabled": false}
  }
}
```

Response includes `chunks` and `stats` with per-stage breakdown.

## Files

- `pkg/pipeline/pipeline.go` + `pipeline_test.go` (9 tests)
- `cmd/pipeline.go` — CLI command
- `cmd/api_pipeline.go` — HTTP handlers (also wires batch routes)
- `cmd/api.go` — registers `/v1/pipeline` and `/v1/batch/*`
