### PR TITLE
build: include shell completion scripts in GoReleaser archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated shell completion scripts (produced by scripts/completions.sh)
+completions/
+
 # Binaries
 distill
 *.exe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@ version: 2
 
 before:
   hooks:
+    - ./scripts/completions.sh
     - go mod tidy
 
 builds:
@@ -28,6 +29,8 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - completions/*
 
 checksum:
   name_template: 'checksums.txt'

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+rm -rf completions
+mkdir -p completions
+
+# Generate shell completion scripts for all supported shells
+for sh in bash zsh fish powershell; do
+  go run . completion "$sh" > "completions/distill.$sh"
+done
+


### PR DESCRIPTION
Picks up the GoReleaser and script additions from #35 that weren't covered by #68.

## Changes

- `scripts/completions.sh` — generates `completions/distill.{bash,zsh,fish,powershell}` using `go run . completion`
- `.goreleaser.yml` — runs the script as a pre-hook and bundles `completions/*` in release archives
- `.gitignore` — excludes the generated `completions/` directory

Users installing via a release archive will get completion scripts alongside the binary.