### PR TITLE
feat(embedding): add Ollama tests and multi-provider support

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -13,7 +13,10 @@ import (
 
 	distillcache "github.com/Siddhant-K-code/distill/pkg/cache"
 	"github.com/Siddhant-K-code/distill/pkg/contextlab"
-	"github.com/Siddhant-K-code/distill/pkg/embedding/openai"
+	"github.com/Siddhant-K-code/distill/pkg/embedding"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/cohere"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/ollama"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/openai"
 	"github.com/Siddhant-K-code/distill/pkg/metrics"
 	"github.com/Siddhant-K-code/distill/pkg/sse"
 	"github.com/Siddhant-K-code/distill/pkg/telemetry"
@@ -44,7 +47,9 @@ func init() {
 	apiCmd.Flags().IntP("port", "p", 8080, "HTTP server port")
 	apiCmd.Flags().String("host", "0.0.0.0", "HTTP server host")
 	apiCmd.Flags().String("openai-key", "", "OpenAI API key for embeddings (or use OPENAI_API_KEY)")
-	apiCmd.Flags().String("embedding-model", "text-embedding-3-small", "OpenAI embedding model")
+	apiCmd.Flags().String("embedding-provider", "openai", "Embedding provider (openai, ollama, cohere)")
+	apiCmd.Flags().String("embedding-model", "text-embedding-3-small", "Embedding model name")
+	apiCmd.Flags().String("embedding-base-url", "", "Embedding provider base URL (e.g. http://localhost:11434 for Ollama)")
 	apiCmd.Flags().String("api-keys", "", "Comma-separated list of valid API keys (or use DISTILL_API_KEYS)")
 	apiCmd.Flags().Bool("memory", false, "Enable persistent memory store")
 	apiCmd.Flags().Bool("session", false, "Enable session management")
@@ -53,7 +58,9 @@ func init() {
 	// Bind to viper for config file support
 	_ = viper.BindPFlag("server.port", apiCmd.Flags().Lookup("port"))
 	_ = viper.BindPFlag("server.host", apiCmd.Flags().Lookup("host"))
+	_ = viper.BindPFlag("embedding.provider", apiCmd.Flags().Lookup("embedding-provider"))
 	_ = viper.BindPFlag("embedding.model", apiCmd.Flags().Lookup("embedding-model"))
+	_ = viper.BindPFlag("embedding.base_url", apiCmd.Flags().Lookup("embedding-base-url"))
 }
 
 // DedupeRequest is the JSON request body for /v1/dedupe.
@@ -117,7 +124,7 @@ type DedupeStats struct {
 
 // APIServer holds the API server state.
 type APIServer struct {
-	embedder  *openai.Client
+	embedder  embedding.Provider
 	validKeys map[string]bool
 	hasAuth   bool
 	metrics   *metrics.Metrics
@@ -131,6 +138,12 @@ func runAPI(cmd *cobra.Command, args []string) error {
 	openaiKey, _ := cmd.Flags().GetString("openai-key")
 	embeddingModel := viper.GetString("embedding.model")
 	apiKeysStr, _ := cmd.Flags().GetString("api-keys")
+
+	embeddingProvider := viper.GetString("embedding.provider")
+	embeddingBaseURL, _ := cmd.Flags().GetString("embedding-base-url")
+	if embeddingBaseURL == "" {
+		embeddingBaseURL = viper.GetString("embedding.base_url")
+	}
 
 	// Resolve from environment
 	if openaiKey == "" {
@@ -151,13 +164,26 @@ func runAPI(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Create embedding provider if OpenAI key is provided
-	var embedder *openai.Client
-	if openaiKey != "" {
+	// Create embedding provider via registry
+	var embedder embedding.Provider
+	needsAPIKey := embeddingProvider == "" || embeddingProvider == "openai" || embeddingProvider == "cohere"
+	if needsAPIKey && openaiKey == "" {
+		// No API key and cloud provider selected — embeddings disabled
+	} else {
+		apiKey := openaiKey
+		if embeddingProvider == "cohere" && apiKey == "" {
+			apiKey = os.Getenv("COHERE_API_KEY")
+		}
+		if embeddingProvider == "" {
+			embeddingProvider = "openai"
+		}
 		var err error
-		embedder, err = openai.NewClient(openai.Config{
-			APIKey: openaiKey,
-			Model:  embeddingModel,
+		embedder, err = embedding.NewProvider(embedding.ProviderConfig{
+			Type:      embedding.ProviderType(embeddingProvider),
+			APIKey:    apiKey,
+			Model:     embeddingModel,
+			BaseURL:   embeddingBaseURL,
+			CacheSize: -1, // caching handled at a higher layer
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create embedding provider: %w", err)

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Siddhant-K-code/distill/pkg/embedding/openai"
+	"github.com/Siddhant-K-code/distill/pkg/embedding"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/cohere"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/ollama"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/openai"
 	"github.com/Siddhant-K-code/distill/pkg/memory"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -67,7 +70,8 @@ func init() {
 	memoryStoreCmd.Flags().String("source", "", "Source of the memory (e.g., code_review, docs)")
 	memoryStoreCmd.Flags().StringSlice("tags", nil, "Tags for the memory")
 	memoryStoreCmd.Flags().String("session-id", "", "Session ID")
-	memoryStoreCmd.Flags().String("openai-key", "", "OpenAI API key for embeddings (or OPENAI_API_KEY)")
+	memoryStoreCmd.Flags().String("openai-key", "", "API key for embeddings (or OPENAI_API_KEY / COHERE_API_KEY)")
+	memoryStoreCmd.Flags().String("embedding-provider", "", "Embedding provider (openai, ollama, cohere)")
 
 	// Recall flags
 	memoryRecallCmd.Flags().String("query", "", "Query text")
@@ -75,7 +79,8 @@ func init() {
 	memoryRecallCmd.Flags().Int("max-results", 10, "Maximum results to return")
 	memoryRecallCmd.Flags().Int("max-tokens", 0, "Maximum token budget (0 = unlimited)")
 	memoryRecallCmd.Flags().Float64("recency-weight", 0.3, "Weight for recency vs relevance (0-1)")
-	memoryRecallCmd.Flags().String("openai-key", "", "OpenAI API key for embeddings (or OPENAI_API_KEY)")
+	memoryRecallCmd.Flags().String("openai-key", "", "API key for embeddings (or OPENAI_API_KEY / COHERE_API_KEY)")
+	memoryRecallCmd.Flags().String("embedding-provider", "", "Embedding provider (openai, ollama, cohere)")
 
 	// Forget flags
 	memoryForgetCmd.Flags().StringSlice("tags", nil, "Remove memories with these tags")
@@ -92,6 +97,47 @@ func openMemoryStore(cmd *cobra.Command) (*memory.SQLiteStore, error) {
 	return memory.NewSQLiteStore(dbPath, cfg)
 }
 
+// createEmbedder builds an embedding.Provider from CLI flags and config.
+func createEmbedder(cmd *cobra.Command) (embedding.Provider, error) {
+	apiKey, _ := cmd.Flags().GetString("openai-key")
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+
+	providerName, _ := cmd.Flags().GetString("embedding-provider")
+	if providerName == "" {
+		providerName = viper.GetString("embedding.provider")
+	}
+	if providerName == "" {
+		providerName = "openai"
+	}
+
+	// Ollama doesn't need an API key
+	needsKey := providerName == "openai" || providerName == "cohere"
+	if needsKey && apiKey == "" {
+		if providerName == "cohere" {
+			apiKey = os.Getenv("COHERE_API_KEY")
+		}
+		if apiKey == "" {
+			return nil, nil // no key available, skip embedding
+		}
+	}
+
+	model := viper.GetString("embedding.model")
+	if model == "" {
+		model = "text-embedding-3-small"
+	}
+	baseURL := viper.GetString("embedding.base_url")
+
+	return embedding.NewProvider(embedding.ProviderConfig{
+		Type:      embedding.ProviderType(providerName),
+		APIKey:    apiKey,
+		Model:     model,
+		BaseURL:   baseURL,
+		CacheSize: -1,
+	})
+}
+
 func runMemoryStore(cmd *cobra.Command, args []string) error {
 	text, _ := cmd.Flags().GetString("text")
 	if text == "" {
@@ -101,10 +147,6 @@ func runMemoryStore(cmd *cobra.Command, args []string) error {
 	source, _ := cmd.Flags().GetString("source")
 	tags, _ := cmd.Flags().GetStringSlice("tags")
 	sessionID, _ := cmd.Flags().GetString("session-id")
-	openaiKey, _ := cmd.Flags().GetString("openai-key")
-	if openaiKey == "" {
-		openaiKey = os.Getenv("OPENAI_API_KEY")
-	}
 
 	store, err := openMemoryStore(cmd)
 	if err != nil {
@@ -118,16 +160,12 @@ func runMemoryStore(cmd *cobra.Command, args []string) error {
 		Tags:   tags,
 	}
 
-	// Generate embedding if OpenAI key is available
-	if openaiKey != "" {
-		model := viper.GetString("embedding.model")
-		if model == "" {
-			model = "text-embedding-3-small"
-		}
-		embedder, err := openai.NewClient(openai.Config{APIKey: openaiKey, Model: model})
-		if err != nil {
-			return fmt.Errorf("create embedder: %w", err)
-		}
+	// Generate embedding if a provider is available
+	embedder, err := createEmbedder(cmd)
+	if err != nil {
+		return fmt.Errorf("create embedder: %w", err)
+	}
+	if embedder != nil {
 		emb, err := embedder.Embed(context.Background(), text)
 		if err != nil {
 			return fmt.Errorf("embed text: %w", err)
@@ -158,10 +196,6 @@ func runMemoryRecall(cmd *cobra.Command, args []string) error {
 	maxResults, _ := cmd.Flags().GetInt("max-results")
 	maxTokens, _ := cmd.Flags().GetInt("max-tokens")
 	recencyWeight, _ := cmd.Flags().GetFloat64("recency-weight")
-	openaiKey, _ := cmd.Flags().GetString("openai-key")
-	if openaiKey == "" {
-		openaiKey = os.Getenv("OPENAI_API_KEY")
-	}
 
 	store, err := openMemoryStore(cmd)
 	if err != nil {
@@ -177,16 +211,12 @@ func runMemoryRecall(cmd *cobra.Command, args []string) error {
 		RecencyWeight: recencyWeight,
 	}
 
-	// Generate query embedding if OpenAI key is available
-	if openaiKey != "" {
-		model := viper.GetString("embedding.model")
-		if model == "" {
-			model = "text-embedding-3-small"
-		}
-		embedder, err := openai.NewClient(openai.Config{APIKey: openaiKey, Model: model})
-		if err != nil {
-			return fmt.Errorf("create embedder: %w", err)
-		}
+	// Generate query embedding if a provider is available
+	embedder, err := createEmbedder(cmd)
+	if err != nil {
+		return fmt.Errorf("create embedder: %w", err)
+	}
+	if embedder != nil {
 		emb, err := embedder.Embed(context.Background(), query)
 		if err != nil {
 			return fmt.Errorf("embed query: %w", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -11,7 +11,10 @@ import (
 	"time"
 
 	"github.com/Siddhant-K-code/distill/pkg/contextlab"
-	"github.com/Siddhant-K-code/distill/pkg/embedding/openai"
+	"github.com/Siddhant-K-code/distill/pkg/embedding"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/cohere"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/ollama"
+	_ "github.com/Siddhant-K-code/distill/pkg/embedding/openai"
 	"github.com/Siddhant-K-code/distill/pkg/metrics"
 	"github.com/Siddhant-K-code/distill/pkg/retriever"
 	"github.com/Siddhant-K-code/distill/pkg/telemetry"
@@ -53,8 +56,10 @@ func init() {
 	serveCmd.Flags().StringP("namespace", "n", "", "Default namespace")
 
 	// Embedding settings
-	serveCmd.Flags().String("openai-key", "", "OpenAI API key for embeddings (or use OPENAI_API_KEY)")
-	serveCmd.Flags().String("embedding-model", "text-embedding-3-small", "OpenAI embedding model")
+	serveCmd.Flags().String("openai-key", "", "API key for embeddings (or use OPENAI_API_KEY / COHERE_API_KEY)")
+	serveCmd.Flags().String("embedding-provider", "openai", "Embedding provider (openai, ollama, cohere)")
+	serveCmd.Flags().String("embedding-model", "text-embedding-3-small", "Embedding model name")
+	serveCmd.Flags().String("embedding-base-url", "", "Embedding provider base URL (e.g. http://localhost:11434 for Ollama)")
 
 	// ContextLab settings
 	serveCmd.Flags().Int("over-fetch-k", 50, "Number of chunks to over-fetch")
@@ -69,7 +74,9 @@ func init() {
 	_ = viper.BindPFlag("retriever.backend", serveCmd.Flags().Lookup("backend"))
 	_ = viper.BindPFlag("retriever.index", serveCmd.Flags().Lookup("index"))
 	_ = viper.BindPFlag("retriever.namespace", serveCmd.Flags().Lookup("namespace"))
+	_ = viper.BindPFlag("embedding.provider", serveCmd.Flags().Lookup("embedding-provider"))
 	_ = viper.BindPFlag("embedding.model", serveCmd.Flags().Lookup("embedding-model"))
+	_ = viper.BindPFlag("embedding.base_url", serveCmd.Flags().Lookup("embedding-base-url"))
 	_ = viper.BindPFlag("retriever.top_k", serveCmd.Flags().Lookup("over-fetch-k"))
 	_ = viper.BindPFlag("retriever.target_k", serveCmd.Flags().Lookup("target-k"))
 	_ = viper.BindPFlag("dedup.threshold", serveCmd.Flags().Lookup("threshold"))
@@ -204,12 +211,31 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = ret.Close() }()
 
-	// Create embedding provider if OpenAI key is provided
+	// Create embedding provider via registry
+	embeddingProvider := viper.GetString("embedding.provider")
+	embeddingBaseURL, _ := cmd.Flags().GetString("embedding-base-url")
+	if embeddingBaseURL == "" {
+		embeddingBaseURL = viper.GetString("embedding.base_url")
+	}
+
 	var embedder retriever.EmbeddingProvider
-	if openaiKey != "" {
-		embedder, err = openai.NewClient(openai.Config{
-			APIKey: openaiKey,
-			Model:  embeddingModel,
+	needsAPIKey := embeddingProvider == "" || embeddingProvider == "openai" || embeddingProvider == "cohere"
+	if needsAPIKey && openaiKey == "" {
+		// No API key and cloud provider selected — embeddings disabled
+	} else {
+		apiKeyForEmbed := openaiKey
+		if embeddingProvider == "cohere" && apiKeyForEmbed == "" {
+			apiKeyForEmbed = os.Getenv("COHERE_API_KEY")
+		}
+		if embeddingProvider == "" {
+			embeddingProvider = "openai"
+		}
+		embedder, err = embedding.NewProvider(embedding.ProviderConfig{
+			Type:      embedding.ProviderType(embeddingProvider),
+			APIKey:    apiKeyForEmbed,
+			Model:     embeddingModel,
+			BaseURL:   embeddingBaseURL,
+			CacheSize: -1,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create embedding provider: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type ServerConfig struct {
 type EmbeddingConfig struct {
 	Provider  string `mapstructure:"provider"`
 	Model     string `mapstructure:"model"`
+	BaseURL   string `mapstructure:"base_url"`
 	BatchSize int    `mapstructure:"batch_size"`
 }
 
@@ -166,9 +167,9 @@ func Validate(cfg *Config) error {
 	}
 
 	// Embedding validation
-	validProviders := map[string]bool{"openai": true, "": true}
+	validProviders := map[string]bool{"openai": true, "ollama": true, "cohere": true, "": true}
 	if !validProviders[cfg.Embedding.Provider] {
-		errs = append(errs, fmt.Sprintf("embedding.provider: unsupported provider %q (supported: openai)", cfg.Embedding.Provider))
+		errs = append(errs, fmt.Sprintf("embedding.provider: unsupported provider %q (supported: openai, ollama, cohere)", cfg.Embedding.Provider))
 	}
 	if cfg.Embedding.BatchSize < 0 {
 		errs = append(errs, "embedding.batch_size: must be non-negative")
@@ -252,6 +253,7 @@ func interpolateConfig(cfg *Config) {
 	cfg.Server.Host = InterpolateEnv(cfg.Server.Host)
 	cfg.Embedding.Provider = InterpolateEnv(cfg.Embedding.Provider)
 	cfg.Embedding.Model = InterpolateEnv(cfg.Embedding.Model)
+	cfg.Embedding.BaseURL = InterpolateEnv(cfg.Embedding.BaseURL)
 	cfg.Dedup.Method = InterpolateEnv(cfg.Dedup.Method)
 	cfg.Dedup.Linkage = InterpolateEnv(cfg.Dedup.Linkage)
 	cfg.Retriever.Backend = InterpolateEnv(cfg.Retriever.Backend)
@@ -281,9 +283,10 @@ server:
   write_timeout: 60s
 
 embedding:
-  provider: openai
+  provider: openai       # openai, ollama, or cohere
   model: text-embedding-3-small
   batch_size: 100
+  # base_url: ""         # override API endpoint (e.g. http://localhost:11434 for Ollama)
 
 dedup:
   threshold: 0.15

--- a/pkg/embedding/ollama/client_test.go
+++ b/pkg/embedding/ollama/client_test.go
@@ -1,0 +1,244 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Siddhant-K-code/distill/pkg/embedding"
+)
+
+func fakeOllamaServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(handler)
+}
+
+func okHandler(dim int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req embedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		emb := make([]float32, dim)
+		for i := range emb {
+			emb[i] = float32(i) * 0.01
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embedResponse{Embedding: emb})
+	}
+}
+
+func TestEmbed_Success(t *testing.T) {
+	srv := fakeOllamaServer(t, okHandler(768))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL, Model: "nomic-embed-text"})
+	emb, err := client.Embed(context.Background(), "hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(emb) != 768 {
+		t.Errorf("expected 768 dimensions, got %d", len(emb))
+	}
+}
+
+func TestEmbed_EmptyInput(t *testing.T) {
+	client := NewClient(Config{})
+	_, err := client.Embed(context.Background(), "")
+	if err != embedding.ErrEmptyInput {
+		t.Errorf("expected ErrEmptyInput, got %v", err)
+	}
+}
+
+func TestEmbed_ServerError(t *testing.T) {
+	srv := fakeOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "model not found", http.StatusNotFound)
+	})
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+	_, err := client.Embed(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestEmbed_EmptyEmbeddingResponse(t *testing.T) {
+	srv := fakeOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embedResponse{Embedding: nil})
+	})
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+	_, err := client.Embed(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for empty embedding")
+	}
+}
+
+func TestEmbed_InvalidJSON(t *testing.T) {
+	srv := fakeOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{invalid"))
+	})
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+	_, err := client.Embed(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestEmbed_ContextCancelled(t *testing.T) {
+	srv := fakeOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+	})
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL, Timeout: 100 * time.Millisecond})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.Embed(ctx, "test")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestEmbed_RequestBody(t *testing.T) {
+	var received embedRequest
+	srv := fakeOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json, got %s", ct)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&received)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embedResponse{Embedding: []float32{0.1}})
+	})
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL, Model: "test-model"})
+	_, _ = client.Embed(context.Background(), "hello")
+
+	if received.Model != "test-model" {
+		t.Errorf("expected model test-model, got %s", received.Model)
+	}
+	if received.Prompt != "hello" {
+		t.Errorf("expected prompt hello, got %s", received.Prompt)
+	}
+}
+
+func TestEmbedBatch_Success(t *testing.T) {
+	srv := fakeOllamaServer(t, okHandler(384))
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+	texts := []string{"hello", "world", "test"}
+	results, err := client.EmbedBatch(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(results))
+	}
+	for i, emb := range results {
+		if len(emb) != 384 {
+			t.Errorf("result[%d]: expected 384 dimensions, got %d", i, len(emb))
+		}
+	}
+}
+
+func TestEmbedBatch_PartialFailure(t *testing.T) {
+	callCount := 0
+	srv := fakeOllamaServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 2 {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embedResponse{Embedding: []float32{0.1}})
+	})
+	defer srv.Close()
+
+	client := NewClient(Config{BaseURL: srv.URL})
+	_, err := client.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	if err == nil {
+		t.Fatal("expected error when one embed in batch fails")
+	}
+}
+
+func TestEmbedBatch_Empty(t *testing.T) {
+	client := NewClient(Config{})
+	results, err := client.EmbedBatch(context.Background(), []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestNewClient_Defaults(t *testing.T) {
+	client := NewClient(Config{})
+	if client.cfg.BaseURL != defaultBaseURL {
+		t.Errorf("expected default base URL %s, got %s", defaultBaseURL, client.cfg.BaseURL)
+	}
+	if client.cfg.Model != defaultModel {
+		t.Errorf("expected default model %s, got %s", defaultModel, client.cfg.Model)
+	}
+	if client.cfg.Timeout != defaultTimeout {
+		t.Errorf("expected default timeout %v, got %v", defaultTimeout, client.cfg.Timeout)
+	}
+}
+
+func TestNewClient_CustomConfig(t *testing.T) {
+	client := NewClient(Config{
+		BaseURL: "http://custom:1234",
+		Model:   "mxbai-embed-large",
+		Timeout: 30 * time.Second,
+	})
+	if client.cfg.BaseURL != "http://custom:1234" {
+		t.Errorf("expected custom base URL, got %s", client.cfg.BaseURL)
+	}
+	if client.cfg.Model != "mxbai-embed-large" {
+		t.Errorf("expected custom model, got %s", client.cfg.Model)
+	}
+	if client.cfg.Timeout != 30*time.Second {
+		t.Errorf("expected 30s timeout, got %v", client.cfg.Timeout)
+	}
+}
+
+func TestDimension(t *testing.T) {
+	client := NewClient(Config{})
+	if client.Dimension() != 0 {
+		t.Errorf("expected 0 (runtime-determined), got %d", client.Dimension())
+	}
+}
+
+func TestModelName(t *testing.T) {
+	client := NewClient(Config{Model: "custom-model"})
+	if client.ModelName() != "custom-model" {
+		t.Errorf("expected custom-model, got %s", client.ModelName())
+	}
+}
+
+func TestEmbed_ConnectionRefused(t *testing.T) {
+	client := NewClient(Config{
+		BaseURL: "http://127.0.0.1:1", // nothing listening
+		Timeout: 1 * time.Second,
+	})
+	_, err := client.Embed(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error for connection refused")
+	}
+}


### PR DESCRIPTION
## What

Adds unit tests for the Ollama embedding client and wires all CLI commands through the embedding provider registry instead of hardcoding OpenAI.

## Why

The Ollama client (`pkg/embedding/ollama`) shipped without tests. The CLI commands (`api`, `serve`, `memory`) only accepted OpenAI, even though the registry already supported Ollama and Cohere.

## Changes

- **15 unit tests** for the Ollama client covering success, errors, empty input, timeouts, batch, and connection failures
- **`--embedding-provider` flag** added to `api`, `serve`, and `memory` commands (accepts `openai`, `ollama`, `cohere`)
- **`--embedding-base-url` flag** for custom endpoints (e.g. `http://localhost:11434` for Ollama)
- **Config validation** updated to accept `ollama` and `cohere` as valid providers
- **`EmbeddingConfig.BaseURL`** field added for config file support

## Usage

```bash
# Use Ollama for embeddings (no API key needed)
distill api --embedding-provider ollama --embedding-model nomic-embed-text

# Use Cohere
distill api --embedding-provider cohere --openai-key $COHERE_API_KEY

# Config file
embedding:
  provider: ollama
  model: nomic-embed-text
  base_url: http://localhost:11434
```

Closes #25