### PR TITLE
feat(memory): add expiry, supersession, and TTL support

### DIFF
--- a/cmd/api_memory.go
+++ b/cmd/api_memory.go
@@ -22,6 +22,8 @@ func (m *MemoryAPI) RegisterMemoryRoutes(mux *http.ServeMux, mw func(string, htt
 	mux.HandleFunc("/v1/memory/store", mw("/v1/memory/store", m.handleStore))
 	mux.HandleFunc("/v1/memory/recall", mw("/v1/memory/recall", m.handleRecall))
 	mux.HandleFunc("/v1/memory/forget", mw("/v1/memory/forget", m.handleForget))
+	mux.HandleFunc("/v1/memory/expire", mw("/v1/memory/expire", m.handleExpire))
+	mux.HandleFunc("/v1/memory/supersede", mw("/v1/memory/supersede", m.handleSupersede))
 	mux.HandleFunc("/v1/memory/stats", mw("/v1/memory/stats", m.handleStats))
 }
 
@@ -103,6 +105,66 @@ func (m *MemoryAPI) handleRecall(w http.ResponseWriter, r *http.Request) {
 	result, err := m.store.Recall(r.Context(), req)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func (m *MemoryAPI) handleExpire(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req memory.ExpireRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if len(req.IDs) == 0 {
+		writeJSONError(w, "ids is required", http.StatusBadRequest)
+		return
+	}
+
+	result, err := m.store.Expire(r.Context(), req)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func (m *MemoryAPI) handleSupersede(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req memory.SupersedeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.OldID == "" {
+		writeJSONError(w, "old_id is required", http.StatusBadRequest)
+		return
+	}
+
+	result, err := m.store.Supersede(r.Context(), req)
+	if err != nil {
+		code := http.StatusInternalServerError
+		if err == memory.ErrNotFound {
+			code = http.StatusNotFound
+		} else if err == memory.ErrAlreadyExpired {
+			code = http.StatusConflict
+		}
+		writeJSONError(w, err.Error(), code)
 		return
 	}
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -443,6 +443,27 @@ Use this to clean up outdated or incorrect memories.`),
 		)
 		s.AddTool(forgetMemoryTool, m.handleForgetMemory)
 
+		expireMemoryTool := mcp.NewTool("memory_expire",
+			mcp.WithDescription("Mark memory entries as expired. Expired entries are excluded from recall by default but remain in the store."),
+			mcp.WithArray("ids",
+				mcp.Description("Memory entry IDs to expire"),
+				mcp.Required(),
+			),
+		)
+		s.AddTool(expireMemoryTool, m.handleExpireMemory)
+
+		supersedeMemoryTool := mcp.NewTool("memory_supersede",
+			mcp.WithDescription("Mark a memory as superseded by a newer entry. The old entry is expired and a forward pointer to the replacement is stored."),
+			mcp.WithString("old_id",
+				mcp.Description("ID of the memory being superseded"),
+				mcp.Required(),
+			),
+			mcp.WithString("new_id",
+				mcp.Description("ID of the replacement memory"),
+			),
+		)
+		s.AddTool(supersedeMemoryTool, m.handleSupersedeMemory)
+
 		memoryStatsTool := mcp.NewTool("memory_stats",
 			mcp.WithDescription("Get statistics about the persistent memory store."),
 		)

--- a/cmd/mcp_memory.go
+++ b/cmd/mcp_memory.go
@@ -144,6 +144,53 @@ func (m *MCPServer) handleForgetMemory(ctx context.Context, request mcp.CallTool
 	return mcp.NewToolResultText(string(out)), nil
 }
 
+func (m *MCPServer) handleExpireMemory(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
+	var ids []string
+	if idsRaw, ok := args["ids"].([]interface{}); ok {
+		for _, id := range idsRaw {
+			if s, ok := id.(string); ok {
+				ids = append(ids, s)
+			}
+		}
+	}
+
+	if len(ids) == 0 {
+		return mcp.NewToolResultError("ids is required"), nil
+	}
+
+	result, err := m.memStore.Expire(ctx, memory.ExpireRequest{IDs: ids})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("expire error: %v", err)), nil
+	}
+
+	out, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+func (m *MCPServer) handleSupersedeMemory(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
+	oldID, _ := args["old_id"].(string)
+	newID, _ := args["new_id"].(string)
+
+	if oldID == "" {
+		return mcp.NewToolResultError("old_id is required"), nil
+	}
+
+	result, err := m.memStore.Supersede(ctx, memory.SupersedeRequest{
+		OldID: oldID,
+		NewID: newID,
+	})
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("supersede error: %v", err)), nil
+	}
+
+	out, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(out)), nil
+}
+
 func (m *MCPServer) handleMemoryStats(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	stats, err := m.memStore.Stats(ctx)
 	if err != nil {

--- a/pkg/memory/cache_events.go
+++ b/pkg/memory/cache_events.go
@@ -20,6 +20,10 @@ const (
 	// EventEvicted fires when an entry is removed from the store entirely.
 	// Any cached prefix that included this entry must retreat.
 	EventEvicted MemoryEventType = "evicted"
+
+	// EventExpired fires when an entry is marked as expired or superseded.
+	// The entry remains in the store but is excluded from recall by default.
+	EventExpired MemoryEventType = "expired"
 )
 
 // MemoryEvent describes a single lifecycle transition for a memory entry.

--- a/pkg/memory/expiry_test.go
+++ b/pkg/memory/expiry_test.go
@@ -1,0 +1,322 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestExpire(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Decision: use Postgres for persistence", Embedding: makeEmbedding(0, 8), Tags: []string{"arch"}},
+			{Text: "Auth uses JWT with RS256", Embedding: makeEmbedding(1, 8), Tags: []string{"auth"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	// Get the IDs
+	recall, _ := s.Recall(ctx, RecallRequest{
+		Query:          "all",
+		QueryEmbedding: makeEmbedding(0, 8),
+		MaxResults:     10,
+	})
+	if len(recall.Memories) != 2 {
+		t.Fatalf("expected 2 memories, got %d", len(recall.Memories))
+	}
+
+	// Expire the first entry
+	expResult, err := s.Expire(ctx, ExpireRequest{IDs: []string{recall.Memories[0].ID}})
+	if err != nil {
+		t.Fatalf("Expire: %v", err)
+	}
+	if expResult.Expired != 1 {
+		t.Errorf("expected 1 expired, got %d", expResult.Expired)
+	}
+
+	// Recall should now return only 1 entry
+	recall2, _ := s.Recall(ctx, RecallRequest{
+		Query:          "all",
+		QueryEmbedding: makeEmbedding(0, 8),
+		MaxResults:     10,
+	})
+	if len(recall2.Memories) != 1 {
+		t.Errorf("expected 1 active memory after expire, got %d", len(recall2.Memories))
+	}
+
+	// Recall with IncludeExpired should return both
+	recall3, _ := s.Recall(ctx, RecallRequest{
+		Query:          "all",
+		QueryEmbedding: makeEmbedding(0, 8),
+		MaxResults:     10,
+		IncludeExpired: true,
+	})
+	if len(recall3.Memories) != 2 {
+		t.Errorf("expected 2 memories with IncludeExpired, got %d", len(recall3.Memories))
+	}
+}
+
+func TestExpire_AlreadyExpired(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Some fact"}},
+	})
+
+	recall, _ := s.Recall(ctx, RecallRequest{Query: "fact", MaxResults: 1})
+	id := recall.Memories[0].ID
+
+	// Expire once
+	r1, _ := s.Expire(ctx, ExpireRequest{IDs: []string{id}})
+	if r1.Expired != 1 {
+		t.Errorf("first expire: expected 1, got %d", r1.Expired)
+	}
+
+	// Expire again — should affect 0 rows
+	r2, _ := s.Expire(ctx, ExpireRequest{IDs: []string{id}})
+	if r2.Expired != 0 {
+		t.Errorf("second expire: expected 0, got %d", r2.Expired)
+	}
+}
+
+func TestSupersede(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Use distinct embeddings so dedup doesn't merge them
+	oldEmb := makeEmbedding(0, 8)
+	newEmb := makeEmbedding(1.5, 8) // far enough apart to avoid dedup
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Use MySQL for persistence", Embedding: oldEmb, Tags: []string{"arch"}},
+		},
+	})
+
+	// Get the old entry ID
+	recall, _ := s.Recall(ctx, RecallRequest{
+		Query: "persistence", QueryEmbedding: oldEmb, MaxResults: 1,
+	})
+	oldID := recall.Memories[0].ID
+
+	// Store the replacement with a distinct embedding
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Use Postgres for persistence (decision reversed)", Embedding: newEmb, Tags: []string{"arch"}},
+		},
+	})
+
+	recall2, _ := s.Recall(ctx, RecallRequest{
+		Query: "persistence", QueryEmbedding: newEmb, MaxResults: 10,
+	})
+	var newID string
+	for _, m := range recall2.Memories {
+		if m.ID != oldID {
+			newID = m.ID
+			break
+		}
+	}
+	if newID == "" {
+		t.Fatal("could not find new entry ID")
+	}
+
+	// Supersede old with new
+	supResult, err := s.Supersede(ctx, SupersedeRequest{OldID: oldID, NewID: newID})
+	if err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+	if !supResult.Superseded {
+		t.Error("expected Superseded=true")
+	}
+
+	// Recall should only return the new entry
+	recall3, _ := s.Recall(ctx, RecallRequest{
+		Query: "persistence", QueryEmbedding: newEmb, MaxResults: 10,
+	})
+	if len(recall3.Memories) != 1 {
+		t.Fatalf("expected 1 memory after supersede, got %d", len(recall3.Memories))
+	}
+	if recall3.Memories[0].ID != newID {
+		t.Errorf("expected new entry %s, got %s", newID, recall3.Memories[0].ID)
+	}
+}
+
+func TestSupersede_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.Supersede(ctx, SupersedeRequest{OldID: "nonexistent", NewID: "also-nonexistent"})
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestSupersede_AlreadyExpired(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Old decision"}},
+	})
+	recall, _ := s.Recall(ctx, RecallRequest{Query: "decision", MaxResults: 1})
+	id := recall.Memories[0].ID
+
+	// Expire first
+	_, _ = s.Expire(ctx, ExpireRequest{IDs: []string{id}})
+
+	// Supersede should fail with ErrAlreadyExpired
+	_, err := s.Supersede(ctx, SupersedeRequest{OldID: id, NewID: "new-id"})
+	if err != ErrAlreadyExpired {
+		t.Errorf("expected ErrAlreadyExpired, got %v", err)
+	}
+}
+
+func TestExpire_LifecycleEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	var events []MemoryEvent
+	s.OnLifecycleEvent(func(e MemoryEvent) {
+		events = append(events, e)
+	})
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Will be expired"}},
+	})
+	recall, _ := s.Recall(ctx, RecallRequest{Query: "expired", MaxResults: 1})
+
+	_, _ = s.Expire(ctx, ExpireRequest{IDs: []string{recall.Memories[0].ID}})
+
+	if len(events) == 0 {
+		t.Fatal("expected lifecycle event for expire")
+	}
+	if events[0].Type != EventExpired {
+		t.Errorf("expected EventExpired, got %s", events[0].Type)
+	}
+}
+
+func TestStoreWithTTL(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Store with a TTL that has already passed
+	pastExpiry := time.Now().Add(-1 * time.Hour)
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Already expired by TTL", ExpiresAt: &pastExpiry},
+			{Text: "Still valid"},
+		},
+	})
+
+	// Recall should only return the valid entry
+	recall, _ := s.Recall(ctx, RecallRequest{Query: "entry", MaxResults: 10})
+	if len(recall.Memories) != 1 {
+		t.Errorf("expected 1 active memory (TTL-expired excluded), got %d", len(recall.Memories))
+	}
+	if recall.Memories[0].Text != "Still valid" {
+		t.Errorf("expected 'Still valid', got %q", recall.Memories[0].Text)
+	}
+}
+
+func TestStoreWithFutureTTL(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	futureExpiry := time.Now().Add(24 * time.Hour)
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Valid for 24h", ExpiresAt: &futureExpiry},
+		},
+	})
+
+	recall, _ := s.Recall(ctx, RecallRequest{Query: "valid", MaxResults: 10})
+	if len(recall.Memories) != 1 {
+		t.Errorf("expected 1 memory with future TTL, got %d", len(recall.Memories))
+	}
+}
+
+func TestStats_IncludesExpiredCount(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Active entry"},
+			{Text: "Will expire"},
+		},
+	})
+
+	recall, _ := s.Recall(ctx, RecallRequest{Query: "expire", MaxResults: 10})
+	_, _ = s.Expire(ctx, ExpireRequest{IDs: []string{recall.Memories[0].ID}})
+
+	stats, err := s.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.TotalMemories != 2 {
+		t.Errorf("expected 2 total, got %d", stats.TotalMemories)
+	}
+	if stats.ExpiredCount != 1 {
+		t.Errorf("expected 1 expired, got %d", stats.ExpiredCount)
+	}
+	if stats.ActiveCount != 1 {
+		t.Errorf("expected 1 active, got %d", stats.ActiveCount)
+	}
+}
+
+func TestExpire_DedupSkipsExpired(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	emb := makeEmbedding(0, 8)
+
+	// Store and expire an entry
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Original fact", Embedding: emb}},
+	})
+	recall, _ := s.Recall(ctx, RecallRequest{Query: "fact", QueryEmbedding: emb, MaxResults: 1})
+	_, _ = s.Expire(ctx, ExpireRequest{IDs: []string{recall.Memories[0].ID}})
+
+	// Store a new entry with the same embedding — should NOT be deduped
+	result, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Updated fact", Embedding: emb}},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if result.Stored != 1 {
+		t.Errorf("expected 1 stored (expired entry should not dedup), got %d", result.Stored)
+	}
+	if result.Deduplicated != 0 {
+		t.Errorf("expected 0 deduplicated, got %d", result.Deduplicated)
+	}
+}
+
+func TestExpire_EmptyRequest(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	result, err := s.Expire(ctx, ExpireRequest{})
+	if err != nil {
+		t.Fatalf("Expire empty: %v", err)
+	}
+	if result.Expired != 0 {
+		t.Errorf("expected 0 expired, got %d", result.Expired)
+	}
+}
+
+func TestSupersede_EmptyOldID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.Supersede(ctx, SupersedeRequest{OldID: "", NewID: "new"})
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for empty OldID, got %v", err)
+	}
+}

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -511,3 +511,4 @@ func TestStoreEmptyText(t *testing.T) {
 		t.Errorf("expected 1 stored (empty skipped), got %d", result.Stored)
 	}
 }
+

--- a/pkg/memory/sqlite.go
+++ b/pkg/memory/sqlite.go
@@ -70,7 +70,11 @@ func (s *SQLiteStore) migrate() error {
 		decay_level     INTEGER DEFAULT 0,
 		created_at      TEXT NOT NULL,
 		last_referenced TEXT NOT NULL,
-		access_count    INTEGER DEFAULT 0
+		access_count    INTEGER DEFAULT 0,
+		expired         INTEGER DEFAULT 0,
+		expired_at      TEXT DEFAULT '',
+		superseded_by   TEXT DEFAULT '',
+		expires_at      TEXT DEFAULT ''
 	);
 	CREATE TABLE IF NOT EXISTS memory_tags (
 		memory_id TEXT NOT NULL,
@@ -82,9 +86,23 @@ func (s *SQLiteStore) migrate() error {
 	CREATE INDEX IF NOT EXISTS idx_memories_decay ON memories(decay_level);
 	CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
 	CREATE INDEX IF NOT EXISTS idx_memories_referenced ON memories(last_referenced);
+	CREATE INDEX IF NOT EXISTS idx_memories_expired ON memories(expired);
 	`
-	_, err := s.db.Exec(schema)
-	return err
+	if _, err := s.db.Exec(schema); err != nil {
+		return err
+	}
+
+	// Add columns to existing databases that lack them.
+	for _, col := range []struct{ name, def string }{
+		{"expired", "INTEGER DEFAULT 0"},
+		{"expired_at", "TEXT DEFAULT ''"},
+		{"superseded_by", "TEXT DEFAULT ''"},
+		{"expires_at", "TEXT DEFAULT ''"},
+	} {
+		_, _ = s.db.Exec("ALTER TABLE memories ADD COLUMN " + col.name + " " + col.def)
+	}
+
+	return nil
 }
 
 // Store adds entries with write-time deduplication.
@@ -126,10 +144,15 @@ func (s *SQLiteStore) Store(ctx context.Context, req StoreRequest) (*StoreResult
 
 		sessionID := req.SessionID
 
+		expiresAt := ""
+		if entry.ExpiresAt != nil {
+			expiresAt = entry.ExpiresAt.UTC().Format(time.RFC3339Nano)
+		}
+
 		_, err := s.db.ExecContext(ctx,
-			`INSERT INTO memories (id, text, embedding, source, session_id, metadata, decay_level, created_at, last_referenced, access_count)
-			 VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, 0)`,
-			id, entry.Text, embBlob, entry.Source, sessionID, string(metaJSON), now, now,
+			`INSERT INTO memories (id, text, embedding, source, session_id, metadata, decay_level, created_at, last_referenced, access_count, expires_at)
+			 VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, 0, ?)`,
+			id, entry.Text, embBlob, entry.Source, sessionID, string(metaJSON), now, now, expiresAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("insert memory: %w", err)
@@ -166,7 +189,7 @@ func (s *SQLiteStore) Store(ctx context.Context, req StoreRequest) (*StoreResult
 // At larger scale, consider an approximate nearest-neighbor index or caching
 // embeddings in memory.
 func (s *SQLiteStore) findDuplicate(ctx context.Context, embedding []float32) (string, error) {
-	rows, err := s.db.QueryContext(ctx, "SELECT id, embedding FROM memories WHERE embedding IS NOT NULL")
+	rows, err := s.db.QueryContext(ctx, "SELECT id, embedding FROM memories WHERE embedding IS NOT NULL AND expired = 0")
 	if err != nil {
 		return "", err
 	}
@@ -213,9 +236,18 @@ func (s *SQLiteStore) Recall(ctx context.Context, req RecallRequest) (*RecallRes
 		recencyWeight = 1
 	}
 
-	// Build query with optional tag filter
+	// Build query with optional tag filter and expiry exclusion
 	query := "SELECT m.id, m.text, m.embedding, m.source, m.decay_level, m.last_referenced FROM memories m"
 	var args []interface{}
+	var conditions []string
+
+	// Exclude expired entries by default
+	if !req.IncludeExpired {
+		conditions = append(conditions, "m.expired = 0")
+		// Also exclude entries past their TTL
+		conditions = append(conditions, "(m.expires_at = '' OR m.expires_at > ?)")
+		args = append(args, time.Now().UTC().Format(time.RFC3339Nano))
+	}
 
 	if len(req.Tags) > 0 {
 		placeholders := make([]string, len(req.Tags))
@@ -223,7 +255,11 @@ func (s *SQLiteStore) Recall(ctx context.Context, req RecallRequest) (*RecallRes
 			placeholders[i] = "?"
 			args = append(args, tag)
 		}
-		query += " WHERE m.id IN (SELECT memory_id FROM memory_tags WHERE tag IN (" + strings.Join(placeholders, ",") + "))"
+		conditions = append(conditions, "m.id IN (SELECT memory_id FROM memory_tags WHERE tag IN ("+strings.Join(placeholders, ",")+"))")
+	}
+
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -411,6 +447,79 @@ func (s *SQLiteStore) Forget(ctx context.Context, req ForgetRequest) (*ForgetRes
 	}, nil
 }
 
+// Expire marks the given memory IDs as expired.
+func (s *SQLiteStore) Expire(ctx context.Context, req ExpireRequest) (*ExpireResult, error) {
+	if len(req.IDs) == 0 {
+		return &ExpireResult{}, nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	placeholders := make([]string, len(req.IDs))
+	args := []interface{}{now}
+	for i, id := range req.IDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+
+	res, err := s.db.ExecContext(ctx,
+		"UPDATE memories SET expired = 1, expired_at = ? WHERE expired = 0 AND id IN ("+strings.Join(placeholders, ",")+
+			")", args...)
+	if err != nil {
+		return nil, fmt.Errorf("expire memories: %w", err)
+	}
+
+	affected, _ := res.RowsAffected()
+
+	// Emit lifecycle events for expired entries
+	for _, id := range req.IDs {
+		s.emit(MemoryEvent{
+			Type:       EventExpired,
+			EntryID:    id,
+			OccurredAt: time.Now().UTC(),
+		})
+	}
+
+	return &ExpireResult{Expired: int(affected)}, nil
+}
+
+// Supersede marks oldID as expired and records newID as its replacement.
+func (s *SQLiteStore) Supersede(ctx context.Context, req SupersedeRequest) (*SupersedeResult, error) {
+	if req.OldID == "" {
+		return nil, ErrNotFound
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	res, err := s.db.ExecContext(ctx,
+		"UPDATE memories SET expired = 1, expired_at = ?, superseded_by = ? WHERE id = ? AND expired = 0",
+		now, req.NewID, req.OldID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("supersede memory: %w", err)
+	}
+
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		// Check if the entry exists at all
+		var count int
+		if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM memories WHERE id = ?", req.OldID).Scan(&count); err != nil {
+			return nil, err
+		}
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+		return nil, ErrAlreadyExpired
+	}
+
+	s.emit(MemoryEvent{
+		Type:       EventExpired,
+		EntryID:    req.OldID,
+		OccurredAt: time.Now().UTC(),
+	})
+
+	return &SupersedeResult{Superseded: true}, nil
+}
+
 // Stats returns memory store statistics.
 // Each query is scanned and closed before the next to avoid holding
 // the single SQLite connection across multiple result sets.
@@ -425,6 +534,12 @@ func (s *SQLiteStore) Stats(ctx context.Context) (*Stats, error) {
 	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM memories").Scan(&stats.TotalMemories); err != nil {
 		return nil, err
 	}
+
+	// Expired count
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM memories WHERE expired = 1").Scan(&stats.ExpiredCount); err != nil {
+		return nil, err
+	}
+	stats.ActiveCount = stats.TotalMemories - stats.ExpiredCount
 
 	// By decay level - scan and close before next query
 	rows, err := s.db.QueryContext(ctx, "SELECT decay_level, COUNT(*) FROM memories GROUP BY decay_level")

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -10,10 +10,11 @@ import (
 
 // Common errors returned by memory stores.
 var (
-	ErrNotFound     = errors.New("memory not found")
-	ErrEmptyText    = errors.New("entry text is empty")
-	ErrStoreClosed  = errors.New("memory store is closed")
-	ErrInvalidQuery = errors.New("query text is empty")
+	ErrNotFound        = errors.New("memory not found")
+	ErrEmptyText       = errors.New("entry text is empty")
+	ErrStoreClosed     = errors.New("memory store is closed")
+	ErrInvalidQuery    = errors.New("query text is empty")
+	ErrAlreadyExpired  = errors.New("memory is already expired")
 )
 
 // DecayLevel represents how compressed a memory is.
@@ -39,6 +40,10 @@ type Entry struct {
 	CreatedAt      time.Time              `json:"created_at"`
 	LastReferenced time.Time              `json:"last_referenced"`
 	AccessCount    int                    `json:"access_count"`
+	Expired        bool                   `json:"expired"`
+	ExpiredAt      *time.Time             `json:"expired_at,omitempty"`
+	SupersededBy   string                 `json:"superseded_by,omitempty"`
+	ExpiresAt      *time.Time             `json:"expires_at,omitempty"`
 }
 
 // StoreRequest is the input for storing memories.
@@ -54,6 +59,7 @@ type StoreEntry struct {
 	Source    string                 `json:"source,omitempty"`
 	Tags      []string               `json:"tags,omitempty"`
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	ExpiresAt *time.Time             `json:"expires_at,omitempty"`
 }
 
 // StoreResult is the output of a store operation.
@@ -66,12 +72,13 @@ type StoreResult struct {
 
 // RecallRequest is the input for recalling memories.
 type RecallRequest struct {
-	Query         string   `json:"query"`
+	Query          string    `json:"query"`
 	QueryEmbedding []float32 `json:"query_embedding,omitempty"`
-	Tags          []string `json:"tags,omitempty"`
-	MaxTokens     int      `json:"max_tokens,omitempty"`
-	MaxResults    int      `json:"max_results,omitempty"`
-	RecencyWeight float64  `json:"recency_weight,omitempty"`
+	Tags           []string  `json:"tags,omitempty"`
+	MaxTokens      int       `json:"max_tokens,omitempty"`
+	MaxResults     int       `json:"max_results,omitempty"`
+	RecencyWeight  float64   `json:"recency_weight,omitempty"`
+	IncludeExpired bool      `json:"include_expired,omitempty"`
 }
 
 // RecallResult is the output of a recall operation.
@@ -115,9 +122,35 @@ type ForgetResult struct {
 	TotalMemories int `json:"total_memories"`
 }
 
+// ExpireRequest marks one or more memories as expired.
+type ExpireRequest struct {
+	IDs []string `json:"ids"`
+}
+
+// ExpireResult is the output of an expire operation.
+type ExpireResult struct {
+	Expired int `json:"expired"`
+}
+
+// SupersedeRequest marks a memory as superseded by a replacement.
+type SupersedeRequest struct {
+	// OldID is the memory being superseded.
+	OldID string `json:"old_id"`
+	// NewID is the replacement memory. If empty, the old entry is simply
+	// marked expired without a forward pointer.
+	NewID string `json:"new_id,omitempty"`
+}
+
+// SupersedeResult is the output of a supersede operation.
+type SupersedeResult struct {
+	Superseded bool `json:"superseded"`
+}
+
 // Stats contains memory store statistics.
 type Stats struct {
 	TotalMemories  int            `json:"total_memories"`
+	ExpiredCount   int            `json:"expired_count"`
+	ActiveCount    int            `json:"active_count"`
 	ByDecayLevel   map[int]int    `json:"by_decay_level"`
 	BySource       map[string]int `json:"by_source"`
 	OldestMemory   time.Time      `json:"oldest_memory,omitempty"`
@@ -131,10 +164,19 @@ type Store interface {
 
 	// Recall retrieves memories matching a query, ranked by relevance and recency.
 	// The result includes a CacheBoundaryHint derived from the recall scores.
+	// Expired entries are excluded by default; set IncludeExpired to retrieve them.
 	Recall(ctx context.Context, req RecallRequest) (*RecallResult, error)
 
 	// Forget removes memories matching the given criteria.
 	Forget(ctx context.Context, req ForgetRequest) (*ForgetResult, error)
+
+	// Expire marks memories as expired. Expired entries are excluded from
+	// recall by default but remain in the store for auditing.
+	Expire(ctx context.Context, req ExpireRequest) (*ExpireResult, error)
+
+	// Supersede marks a memory as superseded by another entry. The old
+	// entry is expired and a forward pointer to the replacement is stored.
+	Supersede(ctx context.Context, req SupersedeRequest) (*SupersedeResult, error)
 
 	// Stats returns memory store statistics.
 	Stats(ctx context.Context) (*Stats, error)


### PR DESCRIPTION
## What

Adds the ability to mark memory entries as expired or superseded, with TTL support on write.

## Why

Memory that can't be pruned becomes noise. When a decision is reversed or information becomes outdated, there was no way to mark it — stale entries degraded retrieval quality over time.

## Changes

### Core (`pkg/memory`)
- **`Expire()`** — marks entries as expired; they remain in the store but are excluded from `Recall` by default
- **`Supersede()`** — marks an entry as expired and stores a forward pointer to its replacement
- **`StoreEntry.ExpiresAt`** — optional TTL; entries past their expiry time are filtered at query time
- **`RecallRequest.IncludeExpired`** — opt-in flag to retrieve expired entries
- **`Stats`** now reports `expired_count` and `active_count`
- Dedup skips expired entries so replacements aren't silently merged
- `EventExpired` lifecycle event for cache boundary managers

### API
- `POST /v1/memory/expire` — expire entries by ID
- `POST /v1/memory/supersede` — supersede one entry with another

### MCP
- `memory_expire` tool
- `memory_supersede` tool

### Tests
- 12 new tests: expire, double-expire, supersede, supersede-not-found, supersede-already-expired, lifecycle events, TTL past/future, stats with expired count, dedup-skips-expired, empty request, empty old_id

## Usage

```bash
# Expire an entry
curl -X POST localhost:8080/v1/memory/expire \
  -d '{"ids": ["abc123"]}'

# Supersede: old decision replaced by new one
curl -X POST localhost:8080/v1/memory/supersede \
  -d '{"old_id": "abc123", "new_id": "def456"}'

# Store with TTL (auto-expires after 24h)
curl -X POST localhost:8080/v1/memory/store \
  -d '{"entries": [{"text": "temp context", "expires_at": "2026-05-10T00:00:00Z"}]}'

# Recall includes expired entries when needed
curl -X POST localhost:8080/v1/memory/recall \
  -d '{"query": "old decisions", "include_expired": true}'
```

Closes #79