### PR TITLE
fix: use tagged switch for staticcheck QF1003

### DIFF
--- a/cmd/api_memory.go
+++ b/cmd/api_memory.go
@@ -159,9 +159,10 @@ func (m *MemoryAPI) handleSupersede(w http.ResponseWriter, r *http.Request) {
 	result, err := m.store.Supersede(r.Context(), req)
 	if err != nil {
 		code := http.StatusInternalServerError
-		if err == memory.ErrNotFound {
+		switch err {
+		case memory.ErrNotFound:
 			code = http.StatusNotFound
-		} else if err == memory.ErrAlreadyExpired {
+		case memory.ErrAlreadyExpired:
 			code = http.StatusConflict
 		}
 		writeJSONError(w, err.Error(), code)


### PR DESCRIPTION
Fixes staticcheck QF1003 lint violation in `handleSupersede` — converts `if/else if` chain on `err` to a `switch` statement.