### PR TITLE
feat(memory): detect and surface conflicting entries on write

### DIFF
--- a/pkg/memory/conflict_test.go
+++ b/pkg/memory/conflict_test.go
@@ -1,0 +1,227 @@
+package memory
+
+import (
+	"context"
+	"testing"
+)
+
+// Angle thresholds for makeEmbedding:
+// cosine_distance(0, x) = 1 - cos(x)
+// dedup threshold 0.15 → angle ~0.55
+// conflict threshold 0.35 → angle ~0.84
+// So angles in (0.55, 0.84) produce conflicts; angles < 0.55 produce dups.
+const (
+	conflictAngle = 0.7  // between dedup (0.55) and conflict (0.84) thresholds
+	farAngle      = 2.0  // well beyond conflict threshold
+)
+
+func TestConflictDetection_SimilarButNotIdentical(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Auth uses JWT with RS256 signing", Embedding: makeEmbedding(0, 8)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store initial: %v", err)
+	}
+
+	// Angle 0.7 → cosine distance ~0.23, above dedup (0.15) but below conflict (0.35)
+	result, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Auth uses HMAC with HS256 signing", Embedding: makeEmbedding(conflictAngle, 8)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store conflicting: %v", err)
+	}
+
+	if result.Stored != 1 {
+		t.Errorf("expected 1 stored, got %d", result.Stored)
+	}
+	if len(result.Conflicts) == 0 {
+		t.Fatal("expected at least 1 conflict, got 0")
+	}
+
+	c := result.Conflicts[0]
+	if c.NewText != "Auth uses HMAC with HS256 signing" {
+		t.Errorf("unexpected NewText: %s", c.NewText)
+	}
+	if c.ExistingText != "Auth uses JWT with RS256 signing" {
+		t.Errorf("unexpected ExistingText: %s", c.ExistingText)
+	}
+	if c.NewID == "" {
+		t.Error("expected NewID to be set")
+	}
+	if c.ExistingID == "" {
+		t.Error("expected ExistingID to be set")
+	}
+	if c.Distance <= 0 {
+		t.Errorf("expected positive distance, got %f", c.Distance)
+	}
+}
+
+func TestConflictDetection_ExactDuplicate_NoConflict(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	emb := makeEmbedding(0, 8)
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Exact duplicate", Embedding: emb}},
+	})
+
+	// Same embedding — should be deduped, not flagged as conflict
+	result, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Exact duplicate again", Embedding: emb}},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if result.Deduplicated != 1 {
+		t.Errorf("expected 1 deduplicated, got %d", result.Deduplicated)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("expected 0 conflicts for exact dup, got %d", len(result.Conflicts))
+	}
+}
+
+func TestConflictDetection_FarApart_NoConflict(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Auth uses JWT", Embedding: makeEmbedding(0, 8)},
+		},
+	})
+
+	// Very different embedding — no conflict
+	result, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Database uses Postgres", Embedding: makeEmbedding(farAngle, 8)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if result.Stored != 1 {
+		t.Errorf("expected 1 stored, got %d", result.Stored)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("expected 0 conflicts for distant entries, got %d", len(result.Conflicts))
+	}
+}
+
+func TestConflictDetection_MultipleConflicts(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Entry1 at angle 0, Entry2 at angle 1.2 (dist=0.64, no dedup between them)
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Deploy to AWS us-east-1", Embedding: makeEmbedding(0, 8)},
+		},
+	})
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Deploy to AWS us-west-2", Embedding: makeEmbedding(1.2, 8)},
+		},
+	})
+
+	// Entry3 at angle 0.6 — equidistant from both (dist=0.17 each, in conflict zone)
+	result, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Deploy to GCP us-central1", Embedding: makeEmbedding(0.6, 8)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if result.Stored != 1 {
+		t.Errorf("expected 1 stored, got %d", result.Stored)
+	}
+	if len(result.Conflicts) < 2 {
+		t.Errorf("expected at least 2 conflicts, got %d", len(result.Conflicts))
+	}
+}
+
+func TestConflictDetection_StillStoresEntry(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Use MySQL", Embedding: makeEmbedding(0, 8)},
+		},
+	})
+
+	result, _ := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Use Postgres", Embedding: makeEmbedding(conflictAngle, 8)},
+		},
+	})
+
+	// Both entries should be in the store
+	recall, _ := s.Recall(ctx, RecallRequest{
+		Query: "database", QueryEmbedding: makeEmbedding(0.35, 8), MaxResults: 10,
+	})
+	if len(recall.Memories) != 2 {
+		t.Errorf("expected 2 memories (conflict doesn't block store), got %d", len(recall.Memories))
+	}
+	if result.Stored != 1 {
+		t.Errorf("expected 1 stored, got %d", result.Stored)
+	}
+}
+
+func TestConflictDetection_NoEmbedding_NoConflict(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Some fact", Embedding: makeEmbedding(0, 8)}},
+	})
+
+	// Store without embedding — no conflict detection possible
+	result, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{{Text: "Related fact"}},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("expected 0 conflicts without embedding, got %d", len(result.Conflicts))
+	}
+}
+
+func TestConflictDetection_ExpiredEntriesIgnored(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, _ = s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "Old decision", Embedding: makeEmbedding(0, 8)},
+		},
+	})
+
+	// Expire the entry
+	recall, _ := s.Recall(ctx, RecallRequest{
+		Query: "decision", QueryEmbedding: makeEmbedding(0, 8), MaxResults: 1,
+	})
+	_, _ = s.Expire(ctx, ExpireRequest{IDs: []string{recall.Memories[0].ID}})
+
+	// Store a similar entry — should NOT conflict with expired entry
+	result, err := s.Store(ctx, StoreRequest{
+		Entries: []StoreEntry{
+			{Text: "New decision", Embedding: makeEmbedding(conflictAngle, 8)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("expected 0 conflicts (expired entry ignored), got %d", len(result.Conflicts))
+	}
+}

--- a/pkg/memory/sqlite.go
+++ b/pkg/memory/sqlite.go
@@ -123,23 +123,42 @@ func (s *SQLiteStore) Store(ctx context.Context, req StoreRequest) (*StoreResult
 			continue
 		}
 
-		// Check for semantic duplicates if embedding is provided
+		// Check for semantic duplicates and conflicts if embedding is provided
 		if len(entry.Embedding) > 0 {
-			dupID, err := s.findDuplicate(ctx, entry.Embedding)
+			similar, err := s.findSimilar(ctx, entry.Embedding)
 			if err != nil {
-				return nil, fmt.Errorf("find duplicate: %w", err)
+				return nil, fmt.Errorf("find similar: %w", err)
 			}
-			if dupID != "" {
-				// Update the existing memory's last_referenced and access_count
-				_, err := s.db.ExecContext(ctx,
-					`UPDATE memories SET last_referenced = ?, access_count = access_count + 1 WHERE id = ?`,
-					time.Now().UTC().Format(time.RFC3339Nano), dupID,
-				)
-				if err != nil {
-					return nil, fmt.Errorf("update duplicate: %w", err)
+
+			// Check for exact duplicate first
+			isDup := false
+			for _, sim := range similar {
+				if sim.isDup {
+					_, err := s.db.ExecContext(ctx,
+						`UPDATE memories SET last_referenced = ?, access_count = access_count + 1 WHERE id = ?`,
+						time.Now().UTC().Format(time.RFC3339Nano), sim.id,
+					)
+					if err != nil {
+						return nil, fmt.Errorf("update duplicate: %w", err)
+					}
+					result.Deduplicated++
+					isDup = true
+					break
 				}
-				result.Deduplicated++
+			}
+			if isDup {
 				continue
+			}
+
+			// Collect conflicts (similar but not identical)
+			// We still store the entry — conflicts are surfaced, not blocked.
+			for _, sim := range similar {
+				result.Conflicts = append(result.Conflicts, Conflict{
+					NewText:      entry.Text,
+					ExistingID:   sim.id,
+					ExistingText: sim.text,
+					Distance:     sim.distance,
+				})
 			}
 		}
 
@@ -186,6 +205,13 @@ func (s *SQLiteStore) Store(ctx context.Context, req StoreRequest) (*StoreResult
 			}
 		}
 
+		// Backfill NewID on any conflicts detected for this entry
+		for i := range result.Conflicts {
+			if result.Conflicts[i].NewID == "" {
+				result.Conflicts[i].NewID = id
+			}
+		}
+
 		result.Stored++
 	}
 
@@ -199,24 +225,39 @@ func (s *SQLiteStore) Store(ctx context.Context, req StoreRequest) (*StoreResult
 	return result, nil
 }
 
-// findDuplicate scans existing embeddings and returns the ID of the first
-// entry within the dedup threshold. Returns "" if no duplicate found.
+// similarEntry describes an existing memory that is semantically close to a
+// new entry. Entries below DedupThreshold are duplicates; entries between
+// DedupThreshold and ConflictThreshold are potential conflicts.
+type similarEntry struct {
+	id       string
+	text     string
+	distance float64
+	isDup    bool
+}
+
+// findSimilar scans existing embeddings and returns duplicates and conflicts.
 //
 // TODO: This does a full table scan (O(n) per insert). Fine for < 10K entries.
 // At larger scale, consider an approximate nearest-neighbor index or caching
 // embeddings in memory.
-func (s *SQLiteStore) findDuplicate(ctx context.Context, embedding []float32) (string, error) {
-	rows, err := s.db.QueryContext(ctx, "SELECT id, embedding FROM memories WHERE embedding IS NOT NULL AND expired = 0")
+func (s *SQLiteStore) findSimilar(ctx context.Context, embedding []float32) ([]similarEntry, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT id, text, embedding FROM memories WHERE embedding IS NOT NULL AND expired = 0")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 
+	conflictThreshold := s.cfg.ConflictThreshold
+	if conflictThreshold <= 0 {
+		conflictThreshold = 0.35
+	}
+
+	var results []similarEntry
 	for rows.Next() {
-		var id string
+		var id, text string
 		var embBlob []byte
-		if err := rows.Scan(&id, &embBlob); err != nil {
-			return "", err
+		if err := rows.Scan(&id, &text, &embBlob); err != nil {
+			return nil, err
 		}
 
 		existing := decodeEmbedding(embBlob)
@@ -226,11 +267,15 @@ func (s *SQLiteStore) findDuplicate(ctx context.Context, embedding []float32) (s
 
 		dist := distillmath.CosineDistance(embedding, existing)
 		if dist < s.cfg.DedupThreshold {
-			return id, nil
+			results = append(results, similarEntry{id: id, text: text, distance: dist, isDup: true})
+			return results, nil // exact dup found, no need to continue
+		}
+		if dist < conflictThreshold {
+			results = append(results, similarEntry{id: id, text: text, distance: dist, isDup: false})
 		}
 	}
 
-	return "", rows.Err()
+	return results, rows.Err()
 }
 
 // Recall retrieves memories matching a query, ranked by relevance and recency.

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -69,10 +69,22 @@ type StoreEntry struct {
 
 // StoreResult is the output of a store operation.
 type StoreResult struct {
-	Stored        int `json:"stored"`
-	Merged        int `json:"merged"`
-	Deduplicated  int `json:"deduplicated"`
-	TotalMemories int `json:"total_memories"`
+	Stored        int        `json:"stored"`
+	Merged        int        `json:"merged"`
+	Deduplicated  int        `json:"deduplicated"`
+	TotalMemories int        `json:"total_memories"`
+	Conflicts     []Conflict `json:"conflicts,omitempty"`
+}
+
+// Conflict describes a semantic conflict between a newly stored entry
+// and an existing memory. The caller can resolve by superseding the old
+// entry, keeping both, or expiring the new one.
+type Conflict struct {
+	NewID       string  `json:"new_id"`
+	NewText     string  `json:"new_text"`
+	ExistingID  string  `json:"existing_id"`
+	ExistingText string `json:"existing_text"`
+	Distance    float64 `json:"distance"`
 }
 
 // RecallRequest is the input for recalling memories.
@@ -211,6 +223,12 @@ type Config struct {
 	// considered duplicates. Default: 0.15.
 	DedupThreshold float64
 
+	// ConflictThreshold is the cosine distance below which entries are
+	// considered semantically related but not identical. Entries in the
+	// range (DedupThreshold, ConflictThreshold] are flagged as conflicts.
+	// Default: 0.35.
+	ConflictThreshold float64
+
 	// DecayEnabled enables the background decay worker.
 	DecayEnabled bool
 
@@ -233,8 +251,9 @@ type Config struct {
 // DefaultConfig returns sensible defaults.
 func DefaultConfig() Config {
 	return Config{
-		DedupThreshold: 0.15,
-		DecayEnabled:   true,
+		DedupThreshold:    0.15,
+		ConflictThreshold: 0.35,
+		DecayEnabled:      true,
 		DecayInterval:  1 * time.Hour,
 		SummaryAge:     24 * time.Hour,
 		KeywordsAge:    168 * time.Hour,


### PR DESCRIPTION
## What

When a new memory entry is semantically similar to an existing one — but not similar enough to be a duplicate — Distill now flags it as a conflict and returns both entries to the caller.

## Why

When new context contradicts something already in memory, Distill previously stored both silently. The agent then operated with conflicting information, producing inconsistent behavior. Now the caller knows about the conflict and can resolve it (supersede the old entry, expire the new one, or keep both).

## How it works

Two thresholds define three zones:

```
cosine distance:  0 ──── 0.15 ──── 0.35 ──── 1.0
                  │  duplicate  │  conflict  │  unrelated  │
                  │  (merged)   │  (flagged)  │  (stored)   │
```

- **< DedupThreshold (0.15)**: Exact semantic duplicate → merged, access count bumped
- **DedupThreshold to ConflictThreshold (0.35)**: Conflict → stored AND flagged in response
- **> ConflictThreshold**: Unrelated → stored normally

Conflicts are surfaced, not blocked. The entry is always stored.

## Changes

- `Config.ConflictThreshold` — configurable conflict zone boundary (default: 0.35)
- `StoreResult.Conflicts` — list of `Conflict` structs with `NewID`, `NewText`, `ExistingID`, `ExistingText`, `Distance`
- Refactored `findDuplicate` → `findSimilar` returning both duplicates and conflicts
- Expired entries excluded from conflict detection
- 7 new tests

## Usage

```bash
curl -X POST localhost:8080/v1/memory/store -d '{
  "entries": [{"text": "Auth uses HMAC with HS256", "embedding": [...]}]
}'

# Response when conflict detected:
{
  "stored": 1,
  "conflicts": [{
    "new_id": "abc123",
    "new_text": "Auth uses HMAC with HS256",
    "existing_id": "def456",
    "existing_text": "Auth uses JWT with RS256",
    "distance": 0.23
  }]
}
```

The caller can then resolve with `POST /v1/memory/supersede` to replace the old entry.

Closes #77