### PR TITLE
docs: v2.0 documentation — guides, reference, and examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Distill Documentation
+
+## Guides
+
+- [Getting Started](guides/getting-started.md) — Install, configure, and run your first dedup
+- [Memory](guides/memory.md) — Persistent context memory across sessions
+- [Sessions](guides/sessions.md) — Token-budgeted context windows
+- [MCP Integration](guides/mcp.md) — Use Distill with Claude Desktop, Cursor, and other MCP clients
+- [Deployment](guides/deployment.md) — Docker, binary, and cloud deployment
+
+## Reference
+
+- [API Reference](reference/api.md) — All REST endpoints
+- [Configuration](reference/configuration.md) — Config file, environment variables, CLI flags
+- [OpenAPI Spec](../openapi.yaml) — Machine-readable API specification
+
+## Examples
+
+- [LangChain Integration](examples/langchain.md)
+- [RAG Pipeline](examples/rag-pipeline.md)

--- a/docs/examples/langchain.md
+++ b/docs/examples/langchain.md
@@ -1,0 +1,98 @@
+# LangChain Integration
+
+Use Distill as a persistent memory layer for LangChain agents.
+
+## Setup
+
+```bash
+pip install langchain requests
+```
+
+## Memory wrapper
+
+```python
+import requests
+from langchain.memory import BaseMemory
+
+class DistillMemory(BaseMemory):
+    """LangChain memory backed by Distill's memory API."""
+
+    base_url: str = "http://localhost:8080"
+    api_key: str | None = None
+    agent_id: str = "langchain-agent"
+    memory_key: str = "history"
+
+    @property
+    def memory_variables(self) -> list[str]:
+        return [self.memory_key]
+
+    def _headers(self) -> dict:
+        h = {"Content-Type": "application/json"}
+        if self.api_key:
+            h["Authorization"] = f"Bearer {self.api_key}"
+        return h
+
+    def load_memory_variables(self, inputs: dict) -> dict:
+        query = inputs.get("input", "")
+        resp = requests.post(
+            f"{self.base_url}/v1/memory/recall",
+            headers=self._headers(),
+            json={
+                "query": query,
+                "agent_id": self.agent_id,
+                "top_k": 5,
+            },
+        )
+        resp.raise_for_status()
+        memories = resp.json().get("memories", [])
+        text = "\n".join(m["content"] for m in memories)
+        return {self.memory_key: text}
+
+    def save_context(self, inputs: dict, outputs: dict) -> None:
+        content = f"User: {inputs.get('input', '')}\nAssistant: {outputs.get('output', '')}"
+        requests.post(
+            f"{self.base_url}/v1/memory/store",
+            headers=self._headers(),
+            json={
+                "content": content,
+                "agent_id": self.agent_id,
+                "tags": ["conversation"],
+                "auto_classify": True,
+            },
+        ).raise_for_status()
+
+    def clear(self) -> None:
+        requests.post(
+            f"{self.base_url}/v1/memory/forget",
+            headers=self._headers(),
+            json={"agent_id": self.agent_id},
+        ).raise_for_status()
+```
+
+## Usage with an agent
+
+```python
+from langchain.chat_models import ChatOpenAI
+from langchain.chains import ConversationChain
+
+memory = DistillMemory(
+    base_url="http://localhost:8080",
+    agent_id="my-agent",
+)
+
+chain = ConversationChain(
+    llm=ChatOpenAI(model="gpt-4o"),
+    memory=memory,
+)
+
+# Memories persist across restarts
+response = chain.predict(input="What did we discuss yesterday?")
+```
+
+## Why use Distill instead of LangChain's built-in memory?
+
+- **Persistence** — survives process restarts, stored in SQLite
+- **Deduplication** — repeated context is stored once
+- **Sensitivity tagging** — PII and credentials are flagged automatically
+- **Decay** — old memories lose relevance over time
+- **Conflict detection** — contradictory memories are surfaced

--- a/docs/examples/rag-pipeline.md
+++ b/docs/examples/rag-pipeline.md
@@ -1,0 +1,150 @@
+# RAG Pipeline with Distill
+
+Use Distill's dedup + memory pipeline to build a retrieval-augmented generation system that avoids redundant context and remembers past interactions.
+
+## Architecture
+
+```
+Documents → Distill (dedup + embed) → Memory Store
+                                          ↓
+User Query → Distill (recall) → Ranked Context → LLM → Response
+                                                    ↓
+                                          Distill (store answer)
+```
+
+## Ingest documents
+
+Deduplicate and store document chunks:
+
+```python
+import requests
+
+DISTILL = "http://localhost:8080"
+
+def ingest(chunks: list[str], source: str):
+    """Dedup chunks, then store unique ones as memories."""
+    # Deduplicate
+    resp = requests.post(f"{DISTILL}/v1/dedupe", json={
+        "chunks": chunks,
+    })
+    resp.raise_for_status()
+    unique = resp.json()["unique_chunks"]
+
+    # Store each unique chunk
+    for chunk in unique:
+        requests.post(f"{DISTILL}/v1/memory/store", json={
+            "content": chunk,
+            "agent_id": "rag-pipeline",
+            "tags": ["document", source],
+            "auto_classify": True,
+        }).raise_for_status()
+
+    print(f"Stored {len(unique)}/{len(chunks)} chunks from {source}")
+```
+
+## Query with context
+
+```python
+def query(question: str, llm_fn) -> str:
+    """Recall relevant context and generate an answer."""
+    # Recall from memory
+    resp = requests.post(f"{DISTILL}/v1/memory/recall", json={
+        "query": question,
+        "agent_id": "rag-pipeline",
+        "top_k": 10,
+        "min_relevance": 0.3,
+        "boost_tags": ["document"],
+    })
+    resp.raise_for_status()
+    memories = resp.json()["memories"]
+
+    # Build prompt
+    context = "\n---\n".join(m["content"] for m in memories)
+    prompt = f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
+
+    answer = llm_fn(prompt)
+
+    # Store the Q&A pair for future recall
+    requests.post(f"{DISTILL}/v1/memory/store", json={
+        "content": f"Q: {question}\nA: {answer}",
+        "agent_id": "rag-pipeline",
+        "tags": ["qa"],
+    }).raise_for_status()
+
+    return answer
+```
+
+## Handle stale knowledge
+
+When documents are updated, supersede old memories:
+
+```python
+def update_document(old_memory_id: str, new_content: str):
+    """Replace outdated memory with new version."""
+    # Store new version
+    resp = requests.post(f"{DISTILL}/v1/memory/store", json={
+        "content": new_content,
+        "agent_id": "rag-pipeline",
+        "tags": ["document"],
+    })
+    resp.raise_for_status()
+    new_id = resp.json()["id"]
+
+    # Supersede old version
+    requests.post(f"{DISTILL}/v1/memory/supersede", json={
+        "id": old_memory_id,
+        "new_id": new_id,
+    }).raise_for_status()
+```
+
+## Session-based context window
+
+For multi-turn conversations, use sessions to manage token budgets:
+
+```python
+def create_session():
+    resp = requests.post(f"{DISTILL}/v1/session/create", json={
+        "max_tokens": 4000,
+        "strategy": "sliding_window",
+    })
+    return resp.json()["session_id"]
+
+def add_to_session(session_id: str, role: str, content: str):
+    requests.post(f"{DISTILL}/v1/session/push", json={
+        "session_id": session_id,
+        "entries": [{"role": role, "content": content}],
+    }).raise_for_status()
+
+def get_context(session_id: str) -> list[dict]:
+    resp = requests.post(f"{DISTILL}/v1/session/context", json={
+        "session_id": session_id,
+    })
+    return resp.json()["entries"]
+```
+
+## Full example
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+def llm(prompt: str) -> str:
+    resp = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp.choices[0].message.content
+
+# Ingest
+chunks = [
+    "Distill deduplicates context before sending to LLMs.",
+    "Memory entries decay over time based on access patterns.",
+    "Sensitivity classification detects PII automatically.",
+]
+ingest(chunks, source="distill-docs")
+
+# Query
+answer = query("How does Distill handle sensitive data?", llm)
+print(answer)
+```

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,0 +1,91 @@
+# Deployment
+
+## Docker
+
+```bash
+docker run -p 8080:8080 \
+  -e OPENAI_API_KEY=sk-... \
+  ghcr.io/siddhant-k-code/distill:latest \
+  api --memory --session
+```
+
+With a persistent volume for memory:
+
+```bash
+docker run -p 8080:8080 \
+  -v distill-data:/data \
+  -e OPENAI_API_KEY=sk-... \
+  ghcr.io/siddhant-k-code/distill:latest \
+  api --memory --memory-db /data/memory.db --session --session-db /data/sessions.db
+```
+
+## Docker Compose
+
+```yaml
+version: "3.8"
+services:
+  distill:
+    image: ghcr.io/siddhant-k-code/distill:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    command: api --memory --session
+    volumes:
+      - distill-data:/data
+
+volumes:
+  distill-data:
+```
+
+## Binary
+
+Download from [GitHub Releases](https://github.com/Siddhant-K-code/distill/releases) and run directly:
+
+```bash
+distill api --memory --session
+```
+
+## Fly.io
+
+A `fly.toml` is included in the repository:
+
+```bash
+fly launch
+fly secrets set OPENAI_API_KEY=sk-...
+fly deploy
+```
+
+## Render
+
+A `render.yaml` is included for one-click deployment to Render.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | OpenAI API key for embeddings |
+| `COHERE_API_KEY` | Cohere API key (when using `--embedding-provider cohere`) |
+| `DISTILL_API_KEYS` | Comma-separated API keys for authentication |
+
+## Observability
+
+### Prometheus metrics
+
+Available at `/metrics`:
+
+```bash
+curl localhost:8080/metrics
+```
+
+### OpenTelemetry tracing
+
+```bash
+distill api --otel-endpoint localhost:4317
+# or
+distill api --otel-stdout  # print traces to stdout
+```
+
+### Grafana
+
+Import the dashboard template from `grafana/dashboard.json`.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,134 @@
+# Getting Started
+
+## Install
+
+### Binary (recommended)
+
+Download from [GitHub Releases](https://github.com/Siddhant-K-code/distill/releases):
+
+```bash
+# macOS / Linux
+curl -sSL https://github.com/Siddhant-K-code/distill/releases/latest/download/distill_$(uname -s)_$(uname -m).tar.gz | tar xz
+sudo mv distill /usr/local/bin/
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/siddhant-k-code/distill:latest
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/Siddhant-K-code/distill.git
+cd distill
+make build
+```
+
+## Quick start
+
+### 1. Start the API server
+
+```bash
+# With OpenAI embeddings
+export OPENAI_API_KEY=sk-...
+distill api
+
+# With Ollama (no API key needed)
+distill api --embedding-provider ollama --embedding-model nomic-embed-text
+
+# With memory and sessions enabled
+distill api --memory --session
+```
+
+### 2. Deduplicate context
+
+```bash
+curl -X POST http://localhost:8080/v1/dedupe -H "Content-Type: application/json" -d '{
+  "chunks": [
+    {"id": "1", "text": "JWT tokens use RS256 signing for authentication"},
+    {"id": "2", "text": "Authentication is handled via JWT with RS256 signatures"},
+    {"id": "3", "text": "The database uses PostgreSQL 15 with pgvector"}
+  ],
+  "threshold": 0.15
+}'
+```
+
+Chunks 1 and 2 are semantically identical — Distill keeps one and returns it alongside chunk 3.
+
+### 3. Run the full pipeline
+
+```bash
+curl -X POST http://localhost:8080/v1/pipeline -H "Content-Type: application/json" -d '{
+  "chunks": [
+    {"id": "1", "text": "..."},
+    {"id": "2", "text": "..."}
+  ],
+  "options": {
+    "dedup": true,
+    "compress": true,
+    "cache": true
+  }
+}'
+```
+
+### 4. Store a memory
+
+```bash
+curl -X POST http://localhost:8080/v1/memory/store -H "Content-Type: application/json" -d '{
+  "entries": [{
+    "text": "The auth service uses JWT with RS256",
+    "source": "code_review",
+    "tags": ["auth", "architecture"],
+    "auto_classify": true
+  }]
+}'
+```
+
+### 5. Recall memories
+
+```bash
+curl -X POST http://localhost:8080/v1/memory/recall -H "Content-Type: application/json" -d '{
+  "query": "how does authentication work?",
+  "max_results": 5,
+  "boost_tags": ["auth"]
+}'
+```
+
+## Configuration
+
+Create `~/.distill.yaml` or `distill.yaml` in your project:
+
+```yaml
+server:
+  port: 8080
+  host: 0.0.0.0
+
+embedding:
+  provider: openai       # openai, ollama, or cohere
+  model: text-embedding-3-small
+  # base_url: http://localhost:11434  # for Ollama
+
+memory:
+  db_path: distill-memory.db
+  dedup_threshold: 0.15
+  conflict_threshold: 0.35
+
+pipeline:
+  dedup: true
+  compress: true
+  cache: true
+```
+
+Run `distill config init` to generate a default config file.
+
+## Interactive docs
+
+Start the server and open [http://localhost:8080/docs](http://localhost:8080/docs) for the Swagger UI API explorer.
+
+## Next steps
+
+- [Memory guide](memory.md) — persistent context across sessions
+- [Sessions guide](sessions.md) — token-budgeted context windows
+- [MCP integration](mcp.md) — use with Claude Desktop and Cursor

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,0 +1,91 @@
+# MCP Integration
+
+Distill runs as an [MCP](https://modelcontextprotocol.io/) server, exposing its tools to Claude Desktop, Cursor, and other MCP-compatible clients.
+
+## Start the MCP server
+
+```bash
+# Basic dedup tools
+distill mcp
+
+# With memory and sessions
+distill mcp --memory --session
+
+# With Ollama embeddings
+distill mcp --embedding-provider ollama --embedding-model nomic-embed-text
+```
+
+## Configure Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "distill": {
+      "command": "distill",
+      "args": ["mcp", "--memory", "--session"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+## Configure Cursor
+
+Add to `.cursor/mcp.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "distill": {
+      "command": "distill",
+      "args": ["mcp", "--memory"]
+    }
+  }
+}
+```
+
+## Available tools
+
+### Dedup tools
+
+| Tool | Description |
+|------|-------------|
+| `deduplicate_chunks` | Deduplicate a list of text chunks |
+| `retrieve_deduplicated` | Query vector DB with dedup (requires `--retriever`) |
+| `analyze_redundancy` | Analyze redundancy in a set of chunks |
+
+### Memory tools (requires `--memory`)
+
+| Tool | Description |
+|------|-------------|
+| `store_memory` | Store a memory entry with optional sensitivity tagging |
+| `recall_memory` | Recall memories by query with relevance ranking |
+| `forget_memory` | Remove memories by ID, tag, or age |
+| `memory_expire` | Mark memories as expired |
+| `memory_supersede` | Replace a memory with a newer version |
+| `memory_stats` | Get memory store statistics |
+
+### Session tools (requires `--session`)
+
+| Tool | Description |
+|------|-------------|
+| `create_session` | Create a token-budgeted context window |
+| `push_session` | Add entries to a session |
+| `session_context` | Read the current context window |
+| `delete_session` | Delete a session |
+
+## Example usage in Claude
+
+Once configured, Claude can use Distill tools directly:
+
+> "Store this architecture decision: we're using JWT with RS256 for auth"
+
+Claude will call `store_memory` with the text, and Distill will deduplicate, classify sensitivity, and persist it.
+
+> "What do we know about authentication?"
+
+Claude will call `recall_memory` with the query, and Distill will return ranked, deduplicated memories with sensitivity metadata.

--- a/docs/guides/memory.md
+++ b/docs/guides/memory.md
@@ -1,0 +1,161 @@
+# Memory
+
+Distill provides persistent context memory that survives across sessions. Memories are deduplicated at write time, ranked by relevance and recency at recall, and automatically classified for sensitivity.
+
+## Enable memory
+
+```bash
+distill api --memory
+# or
+distill mcp --memory
+```
+
+## Store
+
+```bash
+curl -X POST localhost:8080/v1/memory/store -d '{
+  "entries": [{
+    "text": "Auth uses JWT with RS256 signing",
+    "source": "code_review",
+    "tags": ["auth", "security"],
+    "auto_classify": true
+  }]
+}'
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | string | Memory content (required) |
+| `embedding` | float[] | Pre-computed embedding (optional — server can generate) |
+| `source` | string | Origin of the memory (e.g. `code_review`, `docs`) |
+| `tags` | string[] | Categorization tags |
+| `metadata` | object | Arbitrary key-value metadata |
+| `sensitivity` | int | Explicit sensitivity level (0-3) |
+| `auto_classify` | bool | Run pattern-based sensitivity classification |
+| `expires_at` | datetime | TTL — memory excluded from recall after this time |
+
+### Sensitivity levels
+
+| Level | Value | Description |
+|-------|-------|-------------|
+| None | 0 | No sensitive content |
+| PII | 1 | Email, phone, credit card, SSN |
+| Internal | 2 | Internal domains, pricing, roadmaps |
+| Credentials | 3 | API keys, tokens, passwords |
+
+When `auto_classify: true`, Distill scans the text for patterns (AWS keys, OpenAI keys, GitHub tokens, emails, etc.) and sets the sensitivity level automatically. Explicit `sensitivity` takes precedence if higher.
+
+### Deduplication
+
+If a new entry's embedding is within the dedup threshold (default: 0.15 cosine distance) of an existing entry, it's merged — the existing entry's `last_referenced` and `access_count` are updated.
+
+### Conflict detection
+
+If a new entry is similar but not identical (between dedup threshold and conflict threshold), it's stored AND flagged:
+
+```json
+{
+  "stored": 1,
+  "conflicts": [{
+    "new_id": "abc123",
+    "new_text": "Auth uses HMAC with HS256",
+    "existing_id": "def456",
+    "existing_text": "Auth uses JWT with RS256",
+    "distance": 0.23
+  }]
+}
+```
+
+The caller can resolve by superseding the old entry.
+
+## Recall
+
+```bash
+curl -X POST localhost:8080/v1/memory/recall -d '{
+  "query": "how does authentication work?",
+  "max_results": 5,
+  "boost_tags": ["auth"],
+  "min_relevance": 0.3,
+  "task_context": "fixing login bugs in code_review"
+}'
+```
+
+### Ranking
+
+Relevance is computed as:
+
+```
+score = (1 - recency_weight) × similarity + recency_weight × recency
+      + 0.1  if any tag matches boost_tags
+      + 0.05 if source appears in task_context
+```
+
+### Response
+
+```json
+{
+  "memories": [...],
+  "max_sensitivity": 1,
+  "sensitive_chunks": [
+    {"chunk_id": "abc123", "sensitivity": 1}
+  ],
+  "stats": {
+    "candidates": 42,
+    "returned": 5,
+    "token_count": 1200
+  }
+}
+```
+
+## Expire
+
+Mark memories as expired without deleting them:
+
+```bash
+curl -X POST localhost:8080/v1/memory/expire -d '{
+  "ids": ["abc123", "def456"]
+}'
+```
+
+Expired entries are excluded from recall by default. Use `"include_expired": true` in recall to retrieve them.
+
+## Supersede
+
+Replace an outdated memory with a newer one:
+
+```bash
+curl -X POST localhost:8080/v1/memory/supersede -d '{
+  "old_id": "abc123",
+  "new_id": "ghi789"
+}'
+```
+
+The old entry is expired and a forward pointer to the replacement is stored.
+
+## Forget
+
+Permanently remove memories:
+
+```bash
+# By ID
+curl -X POST localhost:8080/v1/memory/forget -d '{"ids": ["abc123"]}'
+
+# By tag
+curl -X POST localhost:8080/v1/memory/forget -d '{"tags": ["temp"]}'
+
+# By age
+curl -X POST localhost:8080/v1/memory/forget -d '{"before": "2026-01-01T00:00:00Z"}'
+```
+
+## Decay
+
+Memories decay over time through four levels:
+
+1. **Full** — complete text preserved
+2. **Summary** — extractive summary
+3. **Keywords** — key terms only
+4. **Evicted** — removed from store
+
+Decay is automatic when enabled (`decay_enabled: true` in config). Frequently accessed memories resist decay.

--- a/docs/guides/sessions.md
+++ b/docs/guides/sessions.md
@@ -1,0 +1,101 @@
+# Sessions
+
+Sessions provide token-budgeted context windows for long-running agents. Push context incrementally — Distill deduplicates and compresses to stay within the budget.
+
+## Enable sessions
+
+```bash
+distill api --session
+# or with a custom database path
+distill api --session --session-db my-sessions.db
+```
+
+## Create a session
+
+```bash
+curl -X POST localhost:8080/v1/session/create -d '{
+  "max_tokens": 4000,
+  "dedup_threshold": 0.15,
+  "preserve_recent": 3
+}'
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | string | Auto-generated if empty |
+| `max_tokens` | int | Token budget for the context window |
+| `dedup_threshold` | float | Cosine distance threshold for dedup (default: 0.15) |
+| `preserve_recent` | int | Always keep last N entries at full fidelity |
+
+## Push context
+
+```bash
+curl -X POST localhost:8080/v1/session/push -d '{
+  "session_id": "sess_abc123",
+  "entries": [
+    {"role": "user", "content": "Fix the login bug in auth.go"},
+    {"role": "assistant", "content": "I found the issue in the JWT validation..."}
+  ]
+}'
+```
+
+Response:
+
+```json
+{
+  "added": 2,
+  "deduplicated": 0,
+  "compressed": 1,
+  "tokens_used": 3200,
+  "tokens_remaining": 800
+}
+```
+
+When the token budget is exceeded, older entries are compressed (summary → keywords) to make room.
+
+## Read context
+
+```bash
+curl -X POST localhost:8080/v1/session/context -d '{
+  "session_id": "sess_abc123",
+  "max_tokens": 2000,
+  "role": "assistant"
+}'
+```
+
+Returns entries with their compression level:
+
+```json
+{
+  "entries": [
+    {"role": "user", "content": "Fix the login bug...", "compression_level": "full", "tokens": 120},
+    {"role": "assistant", "content": "JWT validation issue...", "compression_level": "summary", "tokens": 45}
+  ],
+  "total_tokens": 165
+}
+```
+
+## Get session metadata
+
+```bash
+curl "localhost:8080/v1/session/get?session_id=sess_abc123"
+```
+
+## Delete a session
+
+```bash
+curl -X POST localhost:8080/v1/session/delete -d '{
+  "session_id": "sess_abc123"
+}'
+```
+
+## How compression works
+
+As the context window fills up, Distill compresses older entries:
+
+1. **Recent entries** (last N, configurable) — kept at full fidelity
+2. **Medium-age entries** — extractive summary
+3. **Old entries** — keywords only
+4. **Over budget** — evicted
+
+This ensures the most recent context is always complete while older context is preserved in compressed form.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,72 @@
+# API Reference
+
+Start the server with `distill api`. Interactive docs available at [/docs](http://localhost:8080/docs).
+
+Full OpenAPI 3.1 spec: [openapi.yaml](../../openapi.yaml)
+
+## Endpoints
+
+### Dedup
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/dedupe` | Deduplicate chunks |
+| POST | `/v1/dedupe/stream` | Deduplicate with SSE progress |
+
+### Pipeline
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/pipeline` | Run full dedup → compress → cache pipeline |
+
+### Batch
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/batch` | Submit async batch job |
+| GET | `/v1/batch/{job_id}` | Get job status |
+| GET | `/v1/batch/{job_id}/results` | Get job results |
+
+### Memory (requires `--memory`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/memory/store` | Store memories with dedup and sensitivity tagging |
+| POST | `/v1/memory/recall` | Recall by relevance + recency |
+| POST | `/v1/memory/forget` | Remove by ID, tag, or age |
+| POST | `/v1/memory/expire` | Mark as expired (soft delete) |
+| POST | `/v1/memory/supersede` | Replace with newer version |
+| GET | `/v1/memory/stats` | Store statistics |
+
+### Sessions (requires `--session`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/session/create` | Create token-budgeted session |
+| POST | `/v1/session/push` | Push context entries |
+| POST | `/v1/session/context` | Read context window |
+| GET | `/v1/session/get` | Get session metadata |
+| POST | `/v1/session/delete` | Delete session |
+
+### Health
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check |
+| GET | `/metrics` | Prometheus metrics |
+| GET | `/docs` | Swagger UI |
+| GET | `/openapi.yaml` | OpenAPI spec |
+
+## Authentication
+
+Set `--api-keys` or `DISTILL_API_KEYS` to enable API key authentication:
+
+```bash
+distill api --api-keys "key1,key2"
+```
+
+Clients must include the key in the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer key1" localhost:8080/v1/dedupe -d '{...}'
+```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,76 @@
+# Configuration
+
+Distill reads configuration from CLI flags, environment variables, and a config file (`~/.distill.yaml`).
+
+## Precedence
+
+CLI flags > environment variables > config file > defaults.
+
+## Config file
+
+```yaml
+# ~/.distill.yaml
+embedding:
+  provider: openai        # openai | ollama | cohere
+  model: text-embedding-3-small
+  base_url: ""            # override for ollama/custom endpoints
+
+memory:
+  db_path: ~/.distill/memory.db
+  dedup_threshold: 0.15   # cosine distance below which chunks are duplicates
+  conflict_threshold: 0.35
+  decay_rate: 0.01
+
+session:
+  db_path: ~/.distill/sessions.db
+
+server:
+  port: 8080
+  api_keys: []
+```
+
+## CLI flags
+
+### `distill api`
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `--port` | `PORT` | `8080` | Server port |
+| `--api-keys` | `DISTILL_API_KEYS` | — | Comma-separated API keys |
+| `--memory` | — | `false` | Enable memory subsystem |
+| `--memory-db` | — | `~/.distill/memory.db` | SQLite path for memory |
+| `--session` | — | `false` | Enable session subsystem |
+| `--session-db` | — | `~/.distill/sessions.db` | SQLite path for sessions |
+| `--embedding-provider` | — | `openai` | Embedding provider |
+| `--embedding-model` | — | `text-embedding-3-small` | Embedding model |
+| `--embedding-base-url` | — | — | Custom base URL |
+| `--otel-endpoint` | — | — | OTLP gRPC endpoint |
+| `--otel-stdout` | — | `false` | Print traces to stdout |
+
+### `distill serve` (MCP mode)
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `--memory` | — | `false` | Enable memory tools |
+| `--memory-db` | — | `~/.distill/memory.db` | SQLite path |
+| `--embedding-provider` | — | `openai` | Embedding provider |
+| `--embedding-model` | — | `text-embedding-3-small` | Embedding model |
+| `--embedding-base-url` | — | — | Custom base URL |
+
+### `distill memory`
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--db` | `~/.distill/memory.db` | SQLite path |
+| `--embedding-provider` | `openai` | Embedding provider |
+| `--embedding-model` | `text-embedding-3-small` | Embedding model |
+| `--embedding-base-url` | — | Custom base URL |
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | OpenAI API key |
+| `COHERE_API_KEY` | Cohere API key |
+| `DISTILL_API_KEYS` | Comma-separated API keys for auth |
+| `PORT` | Server port |


### PR DESCRIPTION
Adds complete documentation for Distill v2.0 features.

## What's included

**Guides**
- Getting started — install, configure, first API call
- Memory — store, recall, expire, supersede, sensitivity, conflicts, decay
- Sessions — create, push context, compression strategies
- MCP — Claude Desktop and Cursor integration
- Deployment — Docker, binary, Fly.io, Render, observability

**Reference**
- API — all REST endpoints with auth details
- Configuration — config file, env vars, CLI flags

**Examples**
- LangChain integration with a `DistillMemory` wrapper
- RAG pipeline with dedup, recall, supersession, and sessions

Closes #8